### PR TITLE
v0.8.1: deprecate semi_trusted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 This project follows Semantic Versioning:
 https://semver.org/
 
+## [0.8.1] - 2026-05-07
+
+### Added
+- **`PICSemiTrustedDeprecationWarning`** (`pic_standard.verifier`) — fires at the model-validation boundary when a `Provenance` is constructed with `trust='semi_trusted'`, whether via `verify_proposal()` or via direct model construction. Replaces silent acceptance with explicit deprecation signaling. Subclasses `FutureWarning` (visible by default in Python's warning filters) to ensure producers actually see the migration signal.
+- **Pydantic field validator on `Provenance.trust`** (`mode='before'`) — the canonical normalization boundary for the deprecated value. Normalizes `"semi_trusted"` → `"untrusted"` at construction time and emits the deprecation warning. Applies in all modes (not only `strict_trust=True`). Any construction path that bypasses this validator is non-conformant with the v0.8.1 behavior contract.
+- **Bridge helper in `pic_standard.pipeline`** (`_normalize_provenance_entries_via_model_validator`) — triggers the canonical field validator immediately after JSON Schema validation in `verify_proposal()`, so the deprecation warning fires regardless of `strict_trust` mode and `semi_trusted` is normalized to `"untrusted"` before strict-trust flattening or evidence verification consume the dict. Full `ActionProposal` instantiation still happens later in the pipeline, after evidence verification, so `verify_causal_contract` continues to observe the final post-evidence trust state.
+- **Package-root re-export** for both deprecation warning classes: `from pic_standard import PICSemiTrustedDeprecationWarning, PICTrustFutureWarning`. The existing deep-import paths (`pic_standard.verifier`, `pic_standard.pipeline`) continue to work; re-export is additive and pinned by a small public-API assertion test.
+- **Test coverage** for the new warning in `tests/test_trust_deprecation_warning.py`, including:
+  - Direct-construction tests (string and enum forms) on `Provenance`.
+  - Cascade tests via `ActionProposal` proving per-entry warning cardinality.
+  - `verify_proposal()` flow tests in both non-strict and `strict_trust=True` modes (the latter is the load-bearing Path A property).
+  - Mixed-provenance and "no `semi_trusted` present" regression guards.
+  - A **verdict-regression matrix** (parametrized, 24 rows across 6 example proposals × the `strict_trust × verify_evidence` matrix) that pins the v0.8.0 baseline `verify_proposal()` outcomes (`ok` and `error.code` only — stable fields, asserted against `PICErrorCode` enum members, no free-text). Stays in the suite as a permanent CI guard against any future refactor that touches the dict-vs-model boundary. Includes an explicit canary case (`financial_hash_ok.json` with `verify_evidence=True`) that would flip from `ok=True` to `ok=False` if full instantiation ever moved ahead of evidence verification.
+
+### Deprecated
+- **`provenance[].trust == "semi_trusted"`** is **deprecated** in v0.8.1. Producers MUST migrate to `"untrusted"`. The value is normalized to `"untrusted"` automatically, in all modes, by the model-validation boundary, and a `PICSemiTrustedDeprecationWarning` is emitted on every `Provenance` construction with the deprecated value. **Removal is scheduled for v0.9.0**, where the value will fail JSON Schema validation and be removed from the `TrustLevel` enum entirely. See `docs/migration-trust-sanitization.md` for the full trajectory and producer migration path.
+
+### Changed
+- **`examples/financial_irreversible.json`** and **`examples/robotic_action.json`** — migrated off `trust: "semi_trusted"` to `trust: "untrusted"`. Trust-flip only; no hash evidence added. Adding hash evidence to a Slack message or voice transcript would have been semantically misleading (hash binds bytes, not authority) and risked teaching the wrong security intuition given that PIC's evidence flow upgrades trust on successful hash verification. The existing trusted provenance entries (`cfo_signed_invoice_hash`, `lidar_safety_trigger`) remain the load-bearing sources; the migrated entries stay as honest `untrusted` corroboration.
+- **`verify_proposal()`** now triggers the `Provenance.trust` field validator immediately after JSON Schema validation, so deprecated `semi_trusted` inputs warn and normalize before strict-trust flattening or evidence verification. Full `ActionProposal` instantiation still occurs later in the pipeline, after evidence verification, so contract enforcement (`verify_causal_contract`) continues to observe the final trust state and existing verdict behavior is preserved end-to-end.
+- **`docs/migration-trust-sanitization.md`** — `semi_trusted` Q&A flipped from "(planned)" to "(this release)" tense; new `v0.8.1` row added to the Timeline table; example file migration noted explicitly.
+
+### Notes
+- **The proposal JSON Schema (`proposal_schema.json`) still accepts `"semi_trusted"` in v0.8.1.** Runtime normalizes the value at the model-validation boundary; the schema enum is unchanged in this release. Schema-level removal happens in v0.9.0 per the migration trajectory in `docs/migration-trust-sanitization.md`.
+- **No canonicalization changes.** PIC-CJSON/1.0 remains frozen at v0.8.0.
+- **No conformance manifest changes.** Existing vectors continue to pass.
+- **No wire format change.** Existing v0.8.0 proposals continue to parse, verify, and produce the same allow/block verdicts under v0.8.1 (the verdict-regression matrix codifies this guarantee).
+
+---
+
 ## [0.8.0] - 2026-04-20
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # PIC Standard — Enterprise-Ready Roadmap
 
 > Living plan for standardization, interop, and enterprise adoption.
-> Updated for the post-v0.8.0 repo state (2026-04-28).
+> Updated for the post-v0.8.1 repo state (2026-05-07).
 
 ---
 
@@ -59,8 +59,8 @@ Specifications in this project are treated as evolving drafts until cross-implem
 |------|--------|
 | `docs/canonicalization.md` (PIC-CJSON/1.0) | **Frozen at v0.8.0** — exceptional case; clean external grounding in RFC 8785 made early freeze safe |
 | `docs/attestation-object-draft.md` | DRAFT throughout v0.8.x; refined under cross-impl pressure in v0.9.x; promoted to normative at v1.0 |
-| `docs/spec-core.md` | Initial DRAFT in v0.8.1; evolves through v0.9.x; promoted to normative at v1.0 |
-| `docs/spec-evidence.md` | Initial DRAFT in v0.8.1; evolves through v0.9.x; promoted to normative at v1.0 |
+| `docs/spec-core.md` | Initial DRAFT in v0.8.2 (deferred from v0.8.1); evolves through v0.9.x; promoted to normative at v1.0 |
+| `docs/spec-evidence.md` | Initial DRAFT in v0.8.2 (deferred from v0.8.1); evolves through v0.9.x; promoted to normative at v1.0 |
 
 **Rationale:** A spec is genuinely frozen only when independent implementations have exposed its ambiguities. Freezing before cross-impl conformance produces specs that look authoritative but in fact have unresolved corner cases. PIC-CJSON/1.0 is the exception because RFC 8785 provided the missing external grounding before any second implementation existed.
 
@@ -72,9 +72,9 @@ Specifications in this project are treated as evolving drafts until cross-implem
 |---------|-------|-----------|--------|
 | v0.7.5 | Trust hardening + attestation draft | `strict_trust` pipeline option, `PICTrustFutureWarning`, attestation object draft, migration guide | ✅ Done |
 | **v0.8.0** | **Canonicalization foundation + conformance skeleton** | **PIC Canonical JSON v1 spec (frozen), reference implementation (`pic_standard.canonical`), 9 canonicalization vectors, refined attestation-object draft with byte-level digests, `conformance/` suite first pass, `conformance/manifest.json`, `python -m conformance.run`, `PIC Conformance` CI job** | ✅ Done |
-| **Phase 0 cleanup** | **Repo hygiene** | **`ROADMAP.md` committed, broken roadmap-link refs fixed, `semi_trusted` deprecation trajectory documented, `SECURITY.md`, `CODE_OF_CONDUCT.md`** | 🔄 Next |
-| **v0.8.1** | **Semantics layering + conformance expansion + `semi_trusted` deprecation** | **Evidence-mode vectors, trust-sanitization vectors, runner hardening (JSON output, run-by-id/mode, machine-readable failure reporting), initial DRAFT `docs/spec-core.md`, initial DRAFT `docs/spec-evidence.md`, `semi_trusted` deprecated with `PICSemiTrustedDeprecationWarning` (schema still accepts; all ingestion paths normalize to `untrusted` at parse time; examples updated)** | Planned |
-| **v0.8.2** | **Canonical runtime signing (opt-in)** | **Canonical attestation-object bytes wired into runtime signing/verification flow as an opt-in mode (default remains legacy payload-string for one release). Attestation Object v1 remains DRAFT during this stabilization phase. Legacy mode explicitly demoted to compatibility mode in docs.** | Planned |
+| **Phase 0 cleanup** | **Repo hygiene** | **`ROADMAP.md` committed, broken roadmap-link refs fixed, `semi_trusted` deprecation trajectory documented, `SECURITY.md`, `CODE_OF_CONDUCT.md`** | ✅ Done (PR #67) |
+| **v0.8.1** | **`semi_trusted` deprecation** | **`PICSemiTrustedDeprecationWarning` (defined in `pic_standard.verifier`, re-exported at package root, subclasses `FutureWarning`); pydantic field validator on `Provenance.trust` as the canonical normalization boundary; bridge helper in `verify_proposal()` triggers the validator immediately after JSON Schema validation, so the deprecation warning fires regardless of `strict_trust` mode and `semi_trusted` is normalized to `"untrusted"` before strict-trust flattening or evidence verification consume the dict; full `ActionProposal` instantiation stays last so `verify_causal_contract` keeps observing post-evidence trust state; examples migrated off `semi_trusted` (trust-flip only — no hash evidence added, since hash binds bytes not authority); migration doc `docs/migration-trust-sanitization.md` updated; verdict-regression matrix codified in `tests/test_trust_deprecation_warning.py` as a permanent CI guard. **Other v0.8.1-targeted items from the post-v0.8.0 plan (conformance expansion, runner hardening, initial DRAFTs of `spec-core.md` / `spec-evidence.md`) are deferred to v0.8.2 to keep this release focused on the deprecation surface.** | ✅ Done |
+| **v0.8.2** | **Conformance expansion + runner hardening + initial spec drafts + canonical runtime signing (opt-in)** | **(Deferred from v0.8.1) Evidence-mode vectors, trust-sanitization vectors, runner hardening (JSON output, run-by-id/mode, machine-readable failure reporting), initial DRAFT `docs/spec-core.md`, initial DRAFT `docs/spec-evidence.md`. (v0.8.2 native) Canonical attestation-object bytes wired into runtime signing/verification flow as an opt-in mode (default remains legacy payload-string for one release). Attestation Object v1 remains DRAFT during this stabilization phase. Legacy mode explicitly demoted to compatibility mode in docs.** | Planned |
 | **v0.9.0** | **Interop milestone + schema cleanup** | **First TypeScript verifier pass — minimum: canonicalization + core + trust-sanitization mode parity with Python on the same `conformance/manifest.json`, filtered to those three modes. `semi_trusted` removed from schema (was deprecated in v0.8.1). OpenAPI bridge spec, structured audit logs, Docker hardening for enterprise pilots. Spec drafts updated with cross-impl findings.** | Planned |
 | v0.9.1–v0.9.2 | Ambiguity burn-down | Differential Python ↔ TS testing, fuzzing canonicalization and malformed proposals/evidence, more number/Unicode edge vectors, additional malformed-evidence cases, TS evidence-mode parity completed if not landed at v0.9.0, wording tightening from cross-impl disagreements | Planned |
 | **v1.0.0** | **Production-grade protocol freeze** | **`strict_trust=True` becomes default and only conformant mode. Canonical attestation-object signing becomes default; legacy payload-string mode is non-conformant. `spec-core.md`, `spec-evidence.md`, and Attestation Object v1 all promoted to normative. PIC-CJSON/1.0 unchanged. Python + TS pass full conformance suite. Internet-Draft submission.** | Planned |
@@ -83,7 +83,7 @@ Specifications in this project are treated as evolving drafts until cross-implem
 
 ---
 
-## Current State (post-v0.8.0)
+## Current State (post-v0.8.1)
 
 ### What exists
 
@@ -114,6 +114,11 @@ Specifications in this project are treated as evolving drafts until cross-implem
 | **Conformance runner** | ✅ Done | `conformance/run.py` |
 | **Conformance CI workflow** | ✅ Done | `.github/workflows/conformance.yml` |
 | Canonicalization unit tests | ✅ Done | `tests/test_canonical.py` |
+| **`PICSemiTrustedDeprecationWarning` + field validator (canonical normalization boundary)** | ✅ Done (v0.8.1) | `sdk-python/pic_standard/verifier.py` |
+| **Bridge helper triggering field validator after JSON Schema validation** | ✅ Done (v0.8.1) | `sdk-python/pic_standard/pipeline.py` |
+| **Both deprecation-warning classes re-exported at package root** | ✅ Done (v0.8.1) | `sdk-python/pic_standard/__init__.py` |
+| **Verdict-regression matrix (permanent CI guard for the dict-vs-model boundary)** | ✅ Done (v0.8.1) | `tests/test_trust_deprecation_warning.py` |
+| **Project hygiene: `SECURITY.md`, `CODE_OF_CONDUCT.md`, `CITATION.cff`, README pointers** | ✅ Done (Phase 0, PR #67) | repo root |
 
 ### What still blocks "standard" status
 
@@ -125,9 +130,7 @@ Specifications in this project are treated as evolving drafts until cross-implem
 | Evidence-mode conformance missing | Portable verification of hash/sig evidence not yet part of shared vector execution |
 | Trust-sanitization-mode conformance missing | The v1 trust model must be executable, not just documented |
 | No second verifier implementation | Without Python + TS parity, PIC is not yet proven cross-language |
-| `semi_trusted` lacks strong protocol semantics | Defined in schema but with no normative role under the v0.7.5 Trust Axiom. Trajectory: deprecated v0.8.1 with warning, removed v0.9.0. |
-| `SECURITY.md` + `CODE_OF_CONDUCT.md` missing | OSS credibility / maturity gap |
-| `ROADMAP.md` missing from public main | Internal docs link to it; broken link from public's perspective |
+| `semi_trusted` removal still pending | Deprecation shipped in v0.8.1 (`PICSemiTrustedDeprecationWarning` + canonical normalization at the model-validation boundary). Schema-level removal scheduled for v0.9.0. |
 | Structured audit logs, OpenAPI, Docker hardening incomplete | Enterprise deployment story not yet strong enough |
 | Citation / external publication flow incomplete | Useful for standard-grade credibility |
 
@@ -144,6 +147,7 @@ Specifications in this project are treated as evolving drafts until cross-implem
 | Canonical signing rollout | Opt-in mode at v0.8.2; default at v1.0 | Mirrors `strict_trust` precedent: introduce as opt-in, side-by-side validate, flip default at the v1.0 freeze |
 | `strict_trust` end state | Default and only conformant mode at v1.0 | Prevents config hazards and trust confusion |
 | Trust enum semantics | Binary (`trusted` / `untrusted`) post-v0.9.0; legacy `semi_trusted` value being phased out (deprecated v0.8.1, removed v0.9.0) | The v0.7.5 Trust Axiom collapsed three trust levels into two operational categories; the schema is being reconciled accordingly |
+| `semi_trusted` normalization boundary | Pydantic field validator on `Provenance.trust` (canonical) + bridge helper in `verify_proposal()` triggering it post–JSON-Schema-validation. Any construction path that bypasses the validator is non-conformant | Established in v0.8.1. Locks the boundary against future refactors and gives the eventual TS verifier a clean target ("equivalent of pydantic field validator on the equivalent of `Provenance.trust`"). Verdict-regression matrix in `tests/` codifies this contract as a permanent CI guard |
 | Encoding | JSON core first | Lowest-friction adoption; optional CBOR only later |
 | Standardization target | Standalone PIC spec first, transport bindings second | PIC is broader than any single framework or protocol |
 | `key_id` format | Opaque string | Avoids migration friction and over-prescription |
@@ -152,29 +156,29 @@ Specifications in this project are treated as evolving drafts until cross-implem
 
 ---
 
-## Phase 0 — Repo Hygiene (immediate, single PR)
+## Phase 0 — Repo Hygiene (✅ shipped, PR #67)
 
-**Goal:** complete the minimal public-facing project hygiene expected of a serious protocol candidate. This is one small PR landing before v0.8.1 work begins.
+**Status:** Shipped via PR #67. This section is preserved as historical record of the scope that landed and the decisions made within it. The state-marker work (committing this ROADMAP, removing the stale `.gitignore` entry, adding `SECURITY.md` / `CODE_OF_CONDUCT.md`, bumping `CITATION.cff` to v0.8.0 metadata, adding README pointers, documenting the `semi_trusted` deprecation trajectory in `docs/migration-trust-sanitization.md`) is all on `main`.
 
-### Atomic PR scope
+### Atomic PR scope (as shipped)
 
-- [ ] **Commit `ROADMAP.md` (this file) to main.** Currently exists only on local working copies; tracked references from other docs are broken.
-- [ ] **Fix broken `../ROADMAP.md` references** in `docs/attestation-object-draft.md` (Status banner, Dependencies section, References section) and any other doc that links to `ROADMAP.md`.
-- [ ] **Document `semi_trusted` deprecation trajectory.** It exists in `proposal_schema.json` with no normative semantics under the v0.7.5 Trust Axiom — a vestigial value that suggests a verifier state that doesn't operationally exist. **The decision: deprecate at v0.8.1, remove at v0.9.0.**
-  
+- [x] **Commit `ROADMAP.md` (this file) to main.** Was on local working copies only at session start; tracked references from other docs were broken.
+- [x] **Fix broken `../ROADMAP.md` references** — audit determined no broken refs existed (all `../ROADMAP.md` references in `docs/` resolve correctly to repo root). Item closed without code change.
+- [x] **Document `semi_trusted` deprecation trajectory.** It exists in `proposal_schema.json` with no normative semantics under the v0.7.5 Trust Axiom — a vestigial value that suggests a verifier state that doesn't operationally exist. **The decision: deprecate at v0.8.1, remove at v0.9.0.**
+
   **Origin context (preserved for the record):** `semi_trusted` was day-1 design (introduced January 2026, before v0.1.0) capturing a real-world distinction between "authenticated but not cryptographically signed" and "fully unauthenticated" sources. Examples in the original example proposals: a Slack-authenticated message from a manager (`slack_approval_manager` in `examples/financial_irreversible.json`), a voice-ID-recognized operator command (`operator_voice_command` in `examples/robotic_action.json`). The v0.7.5 Trust Axiom (verifier-derived trust only) made this producer-declared distinction non-authoritative — verifiers can no longer act on producer-declared trust labels regardless of nuance. The original taxonomy collapsed from three levels into two operational categories, and `semi_trusted` became vestigial.
-  
-  **Trajectory:**
-  - **v0.8.1**: deprecated with `PICSemiTrustedDeprecationWarning`. Schema still accepts the value (one transition release). **All public proposal-ingestion paths** normalize `semi_trusted` to `untrusted` at parse time in **all** modes (not just under `strict_trust=True`). This includes `verify_proposal()`, direct `ActionProposal(...)` construction, the HTTP bridge, the LangGraph and MCP integrations, the CLI, and any other entry point that accepts a proposal. The cleanest implementation is normalization at the shared schema-validation boundary, before any verifier rule sees the value — that way every construction path inherits the normalization regardless of entry point, and the requirement is expressed in language-neutral terms that the TypeScript implementation can mirror in its own validation layer. Examples in `examples/*.json` updated to `untrusted` (no semantic change since `semi_trusted` was always advisory under the Trust Axiom). Migration note added to `docs/migration-trust-sanitization.md`.
-  - **v0.9.0**: removed from schema. Validation rejects any proposal with `provenance[].trust = "semi_trusted"`. Schema-validation-layer normalization, the deprecation warning class, and the `SEMI_TRUSTED` enum member in `verifier.py` are all deleted.
-  - **v1.0**: not a concern; already removed.
-  
-  This Phase 0 PR commits the **protocol direction** — deprecate in v0.8.1, remove in v0.9.0 — into `ROADMAP.md`. The actual schema/code/example changes happen in v0.8.1 (deprecation + normalization) and v0.9.0 (removal).
-- [ ] **Add `SECURITY.md`** — vulnerability reporting flow, supported versions, disclosure process.
-- [ ] **Add `CODE_OF_CONDUCT.md`** — standard Contributor Covenant or equivalent.
-- [ ] **Citation flow check** — ensure `CITATION.cff` is complete and the README's "How to cite" section (if any) is accurate.
 
-**Exit criteria:** the repo has the minimum credibility artifacts expected of a security-sensitive open protocol project; no internal links to nonexistent files; `semi_trusted` has a documented deprecation trajectory with a concrete v0.9.0 removal target.
+  **Trajectory:**
+  - **v0.8.1** (✅ shipped): deprecated with `PICSemiTrustedDeprecationWarning`. Schema still accepts the value (one transition release). The canonical normalization boundary is the pydantic field validator on `Provenance.trust` in `pic_standard.verifier`; `verify_proposal()` triggers that validator immediately after JSON Schema validation via a small bridge helper, so warnings fire and `semi_trusted` is normalized to `"untrusted"` regardless of `strict_trust` mode and before strict-trust flattening or evidence verification consume the dict. The `Provenance.trust` validator covers direct `Provenance(...)` / `ActionProposal(...)` construction outside the funnel as well — bypassing it is non-conformant with the v0.8.1 behavior contract. Examples migrated to `untrusted` (no semantic change since `semi_trusted` was always advisory under the Trust Axiom). Migration note added to `docs/migration-trust-sanitization.md`.
+  - **v0.9.0** (planned): removed from schema. Validation rejects any proposal with `provenance[].trust = "semi_trusted"`. The field validator's deprecation branch, the bridge helper, the `PICSemiTrustedDeprecationWarning` class, and the `SEMI_TRUSTED` enum member in `verifier.py` are all deleted.
+  - **v1.0**: not a concern; already removed.
+
+  Phase 0 committed the **protocol direction** — deprecate in v0.8.1, remove in v0.9.0 — into this ROADMAP. The actual schema/code/example changes happened in v0.8.1 (deprecation + normalization, ✅ shipped) and v0.9.0 (removal, planned).
+- [x] **Add `SECURITY.md`** — vulnerability reporting flow, supported versions, disclosure process.
+- [x] **Add `CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1.
+- [x] **Citation flow check** — `CITATION.cff` updated to v0.8.0 metadata + concept DOI + v0.8.0 version DOI; README pointer added.
+
+**Exit criteria (all met):** the repo has the minimum credibility artifacts expected of a security-sensitive open protocol project; no internal links to nonexistent files; `semi_trusted` has a documented deprecation trajectory with a concrete v0.9.0 removal target.
 
 ---
 
@@ -196,7 +200,7 @@ Future canonicalization-related work is not "design canonicalization" but:
 ---
 
 ### 1.2 Conformance expansion
-**Target:** v0.8.1
+**Target:** v0.8.2 (deferred from v0.8.1)
 
 Expand the suite beyond first pass:
 
@@ -226,7 +230,7 @@ Expand the suite beyond first pass:
 ---
 
 ### 1.3 Initial DRAFT Core spec
-**Target:** v0.8.1
+**Target:** v0.8.2 (deferred from v0.8.1)
 
 **File:** `docs/spec-core.md` (DRAFT)
 
@@ -251,7 +255,7 @@ Conformant verifiers MUST treat inbound `provenance[].trust` values as non-autho
 ---
 
 ### 1.4 Initial DRAFT Evidence spec
-**Target:** v0.8.1
+**Target:** v0.8.2 (deferred from v0.8.1)
 
 **File:** `docs/spec-evidence.md` (DRAFT)
 
@@ -304,22 +308,25 @@ Canonical signing in v0.8.2 lands **behind explicit mode selection** (e.g., a `P
 ---
 
 ### 1.6 Schema cleanup: `semi_trusted` deprecation
-**Target:** v0.8.1 (deprecation), v0.9.0 (removal)
+**Target:** v0.8.1 (deprecation, ✅ shipped), v0.9.0 (removal, planned)
 
 Implements the trajectory committed in Phase 0.
 
-#### v0.8.1 work
-- New `PICSemiTrustedDeprecationWarning` warning class in `pipeline.py` (alongside or as a sibling of `PICTrustFutureWarning`).
-- **All public proposal-ingestion paths normalize `provenance[].trust = "semi_trusted"` → `"untrusted"` at parse time, in all modes** (not gated on `strict_trust=True`). The cleanest implementation is normalization at the shared schema-validation boundary, before any verifier rule sees the value — every construction path (`verify_proposal()`, direct `ActionProposal(...)` instantiation, HTTP bridge, LangGraph integration, MCP guard, CLI, and any future ingestion path) inherits the normalization regardless of entry point. The mechanism is intentionally specified in language-neutral terms; Python's reference implementation will likely use a pydantic field validator or equivalent, but the protocol-direction requirement is "normalize at the schema-validation boundary," not "use pydantic specifically." This decouples the deprecation from the strict-trust path **and** eliminates the determinism risk of normalization-by-entry-point (where a pipeline-only patch would let direct verifier construction silently skip normalization).
-- Warning fires once per parse where `semi_trusted` is encountered, with migration guidance message.
-- `examples/financial_irreversible.json` and `examples/robotic_action.json` updated to use `"untrusted"` for the previously-`semi_trusted` provenance entries (no behavioral change since the verifier was already treating these as non-authoritative).
-- New section in `docs/migration-trust-sanitization.md`: "`semi_trusted` deprecation and removal trajectory."
-- CHANGELOG v0.8.1 "Deprecated" entry naming the v0.9.0 removal target.
+#### v0.8.1 work (✅ shipped)
+- ✅ New `PICSemiTrustedDeprecationWarning` warning class — defined in `pic_standard.verifier` (model-layer concern, co-located with the `Provenance` model that fires it), subclasses `FutureWarning` so it's visible in Python's default warning filters, also re-exported at the `pic_standard` package root alongside `PICTrustFutureWarning`.
+- ✅ **Canonical normalization boundary** is a pydantic field validator on `Provenance.trust` (`mode='before'`). Any code path that constructs a `Provenance` (or `ActionProposal`, which cascades) sees the warning + automatic normalization to `"untrusted"`; any path that bypasses the validator is non-conformant with the v0.8.1 behavior contract. Covers direct model construction outside `verify_proposal()` (HTTP bridge, LangGraph, MCP, CLI all funnel through `verify_proposal()`, but the validator is the safety net for any future direct-construction paths).
+- ✅ **Bridge helper in `pic_standard.pipeline`** (`_normalize_provenance_entries_via_model_validator`) triggers the validator on raw provenance entries immediately after JSON Schema validation in `verify_proposal()`. This ensures the warning fires regardless of `strict_trust` mode (without it, strict-trust dict-level flattening would happen first and silently mask the deprecated value). Full `ActionProposal` instantiation still happens later in the pipeline, after evidence verification, so `verify_causal_contract` continues to observe the final post-evidence trust state — the existing `untrusted → evidence verified → trusted` upgrade path is unaffected.
+- ✅ Warning fires once per `Provenance` instance constructed with `semi_trusted` (per-entry, not once-per-proposal). Multiple `semi_trusted` entries in one proposal → multiple warnings.
+- ✅ `examples/financial_irreversible.json` and `examples/robotic_action.json` migrated off `trust: "semi_trusted"` to `trust: "untrusted"`. **Trust-flip only — no hash evidence added.** Adding hash evidence to a Slack message or voice transcript would have been semantically misleading (hash binds bytes, not authority), so the migration is the smallest honest change. The load-bearing `"trusted"` provenance entries (`cfo_signed_invoice_hash`, `lidar_safety_trigger`) are unchanged.
+- ✅ New section in `docs/migration-trust-sanitization.md`: `semi_trusted` deprecation Q&A flipped from "(planned)" to "(this release)" tense; Timeline table gained a v0.8.1 row.
+- ✅ CHANGELOG v0.8.1 "Deprecated" section names the v0.9.0 removal target.
+- ✅ **Verdict-regression matrix** codified in `tests/test_trust_deprecation_warning.py` — parametrized test (24 rows × 6 example proposals × the `strict_trust × verify_evidence` matrix) that pins v0.8.0 baseline `verify_proposal()` outcomes (`ok` and `error.code` only — stable fields, asserted against `PICErrorCode` enum members). Stays in the suite as a permanent CI guard against any future refactor that touches the dict-vs-model boundary.
 
-#### v0.9.0 work
+#### v0.9.0 work (planned)
 - Remove `"semi_trusted"` from the trust enum in `proposal_schema.json`. Schema validation now rejects any proposal containing it.
 - Remove the `SEMI_TRUSTED` enum member from `verifier.py`.
-- Remove the schema-validation-layer normalization code path.
+- Remove the `Provenance.trust` field validator's `semi_trusted` branch (the validator may be removed entirely or kept for future deprecation patterns).
+- Remove the `_normalize_provenance_entries_via_model_validator` bridge helper from `pipeline.py`.
 - Remove the `PICSemiTrustedDeprecationWarning` class.
 - CHANGELOG v0.9.0 "Removed" entry; references the v0.8.1 deprecation cycle.
 
@@ -472,12 +479,12 @@ These are important but stay downstream of a stable core:
 
 | # | PR | Phase | Target |
 |---|----|-------|--------|
-| 1 | **Phase 0 hygiene PR**: commit ROADMAP.md, fix broken roadmap-link refs, document `semi_trusted` deprecation trajectory (Path B: deprecate v0.8.1, remove v0.9.0), add SECURITY.md and CODE_OF_CONDUCT.md | 0 | immediate |
-| 2 | Conformance expansion: evidence-mode + trust-sanitization vectors | 1.2 | v0.8.1 |
-| 3 | Runner hardening: JSON output, filtering, machine-readable diagnostics | 1.2 | v0.8.1 |
-| 4 | Initial DRAFT `docs/spec-core.md` | 1.3 | v0.8.1 |
-| 5 | Initial DRAFT `docs/spec-evidence.md` | 1.4 | v0.8.1 |
-| 6 | `semi_trusted` deprecation: `PICSemiTrustedDeprecationWarning` + schema-validation-layer normalization across all ingestion paths + example updates + migration note | 1.6 | v0.8.1 |
+| 1 | **Phase 0 hygiene PR**: commit ROADMAP.md, fix broken roadmap-link refs, document `semi_trusted` deprecation trajectory (Path B: deprecate v0.8.1, remove v0.9.0), add SECURITY.md and CODE_OF_CONDUCT.md | 0 | ✅ Done (PR #67) |
+| 2 | Conformance expansion: evidence-mode + trust-sanitization vectors | 1.2 | v0.8.2 (deferred from v0.8.1) |
+| 3 | Runner hardening: JSON output, filtering, machine-readable diagnostics | 1.2 | v0.8.2 (deferred from v0.8.1) |
+| 4 | Initial DRAFT `docs/spec-core.md` | 1.3 | v0.8.2 (deferred from v0.8.1) |
+| 5 | Initial DRAFT `docs/spec-evidence.md` | 1.4 | v0.8.2 (deferred from v0.8.1) |
+| 6 | `semi_trusted` deprecation: `PICSemiTrustedDeprecationWarning` + canonical normalization at the model-validation boundary (pydantic field validator on `Provenance.trust` + bridge helper triggering it after JSON Schema validation) + example trust-flips + migration note + verdict-regression matrix | 1.6 | ✅ Done (v0.8.1) |
 | 7 | Wire canonical attestation signing into runtime as opt-in mode (against draft Attestation v1) | 1.5 | v0.8.2 |
 | 8 | `docs/ERRORS.md` formalization | 2.1 | v0.8.2 / v0.9.0 |
 | 9 | `semi_trusted` removal: schema enum drop + code cleanup | 1.6 | v0.9.0 |
@@ -498,14 +505,16 @@ PIC already has the hardest foundation work behind it:
 - Trust-hardening direction
 - Canonical byte model (PIC-CJSON/1.0 frozen)
 - Conformance artifacts (canonicalization + core)
+- Trust-enum cleanup in motion (`semi_trusted` deprecated v0.8.1, removal scheduled v0.9.0)
+- Project hygiene (SECURITY/CoC/Citation/ROADMAP all on `main` post-Phase-0)
 
 From here, the shortest path to becoming a standard protocol is:
 
-1. **Finish normative semantics** — `spec-core.md`, `spec-evidence.md` (both DRAFT v0.8.1 → frozen v1.0)
+1. **Finish normative semantics** — `spec-core.md`, `spec-evidence.md` (both DRAFT v0.8.2 → frozen v1.0)
 2. **Complete conformance** — evidence mode, trust-sanitization mode, ambiguity burn-down
 3. **Make canonical bytes the real runtime signing contract** — opt-in v0.8.2, default v1.0
 4. **Build a second verifier** — TypeScript (v0.9.0 minimum scope, v0.9.x full parity)
-5. **Reconcile the trust enum** — `semi_trusted` deprecated v0.8.1, removed v0.9.0
+5. **Reconcile the trust enum** — `semi_trusted` deprecated v0.8.1 (✅), removed v0.9.0
 6. **Freeze behavior** — v1.0.0
 
 That is the path this roadmap follows.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ That channel is end-to-end private to the maintainers and produces a coordinated
 
 ## What to include in a report
 
-- **Affected version(s):** the PIC release(s) you reproduced the issue on (e.g., 0.8.0)
+- **Affected version(s):** the PIC release(s) you reproduced the issue on (e.g., 0.8.1)
 - **Component:** which part of the codebase is affected (e.g., `pic_standard.canonical`, `pic_standard.verifier`, `integrations/openclaw`, conformance vectors)
 - **Reproduction:** the smallest input or sequence of operations that triggers the issue — include exact commands, file contents, and environment details if relevant
 - **Impact assessment:** what an attacker can do with the issue. Be concrete: information disclosure, signature bypass, denial of service, integrity violation, canonicalization mismatch leading to verification bypass, etc.

--- a/docs/migration-trust-sanitization.md
+++ b/docs/migration-trust-sanitization.md
@@ -26,6 +26,7 @@ This migration changes verifier behavior and integration defaults over time; it 
 |---------|----------|
 | **v0.7.x** | `provenance[].trust` accepted at face value. No warnings. |
 | **v0.8.0** | `PICTrustFutureWarning` emitted when self-asserted `trust="trusted"` is present and effective evidence verification will not run. New `strict_trust` pipeline option available (default `False`). Wire format unchanged. |
+| **v0.8.1** | `PICSemiTrustedDeprecationWarning` emitted when `trust="semi_trusted"` is observed. The value is normalized to `"untrusted"` at the canonical model-validation boundary (the `Provenance.trust` pydantic field validator), in all modes — including strict-trust mode. Schema enum unchanged in v0.8.1. Example files migrated off `semi_trusted` (the project's own surface is clean). |
 | **v1.0** | `strict_trust=True` is the default and the only conformant mode. Non-sanitizing mode is explicitly **legacy and non-conformant** — implementations that disable trust sanitization MUST NOT claim PIC/1.0 conformance. |
 
 ---
@@ -187,11 +188,11 @@ The warning will still fire, because evidence verification will not actually run
 
 **Q: What happens to proposals with `trust: "semi_trusted"`?**
 
-**Today (v0.8.0):** in strict mode, `semi_trusted` is sanitized to `"untrusted"`. Only evidence verification can upgrade trust. The `PICTrustFutureWarning` (described above) only fires for `trust="trusted"` — that warning targets the most dangerous case (self-asserted full trust); `semi_trusted` is handled silently in strict mode.
+**v0.8.1 (this release):** `semi_trusted` is formally deprecated. A `PICSemiTrustedDeprecationWarning` (defined in `pic_standard.verifier`, also re-exported at `pic_standard` package root) fires whenever a `Provenance` is constructed with `trust="semi_trusted"` — whether via `verify_proposal()` or via direct model construction. The value is normalized to `"untrusted"` at the canonical model-validation boundary (the `Provenance.trust` pydantic field validator), in all modes (not only `strict_trust=True`). The repository's own example files have been migrated off `semi_trusted` (`examples/financial_irreversible.json` and `examples/robotic_action.json` now use `"untrusted"` for the affected entries; the load-bearing `"trusted"` entries in those files are unchanged). Producers MUST migrate before v0.9.0.
 
-**v0.8.1 (planned):** `semi_trusted` enters formal deprecation. A new `PICSemiTrustedDeprecationWarning` will fire at all public proposal-ingestion paths (the shared schema-validation boundary) whenever `trust: "semi_trusted"` is observed, regardless of strict-trust mode. The warning cites this guide and the [PIC Roadmap](../ROADMAP.md) for context.
+**Pre-v0.8.1 baseline (v0.8.0):** prior to v0.8.1, `semi_trusted` was silently sanitized to `"untrusted"` only in `strict_trust=True` mode and accepted as-is otherwise. The `PICTrustFutureWarning` (described above) only fires for `trust="trusted"`; it has never targeted `semi_trusted`. This pre-v0.8.1 behavior is preserved as historical context only — v0.8.1+ should be considered the canonical behavior.
 
-**v0.9.0 (planned):** `"semi_trusted"` is **removed** from the trust enum entirely. Proposals carrying it will fail schema validation. The only conformant trust values become `"trusted"` and `"untrusted"`, with `"trusted"` requiring evidence verification under strict mode (the v1.0 default).
+**v0.9.0 (planned):** `"semi_trusted"` is **removed** from the trust enum entirely. Proposals carrying it will fail JSON Schema validation. The only conformant trust values become `"trusted"` and `"untrusted"`, with `"trusted"` requiring evidence verification under strict mode (the v1.0 default).
 
 **Migration path for producers using `trust: "semi_trusted"` today:**
 1. Treat the value as deprecated immediately. Plan to remove it before v0.9.0.
@@ -199,7 +200,7 @@ The warning will still fire, because evidence verification will not actually run
 3. If the proposal carries verifiable evidence (hash, signature, attestation), keep that evidence attached and let the verifier derive effective trust from successful verification.
 4. Do not rely on producer-declared trust labels for authorization. Under the trust axiom (v0.7.5), inbound `trust` is non-authoritative; only verifier-controlled context or successful evidence verification can establish trusted status.
 
-See the [PIC Roadmap](../ROADMAP.md) — Phase 0 (this entry) and Phase 1 (`semi_trusted` deprecation in v0.8.1) — for the full trajectory and rationale.
+See the [PIC Roadmap](../ROADMAP.md) for the full trajectory and rationale.
 
 ---
 

--- a/docs/spec-status.md
+++ b/docs/spec-status.md
@@ -15,10 +15,11 @@
 | v0.7.1 | Deferred integration imports, CLI import isolation, specification status note | None — packaging/docs hygiene only |
 | v0.7.5 | Trust sanitization (`strict_trust`), deprecation warning for self-asserted trust, attestation object draft, migration guide | None — behavioral option only; wire format unchanged |
 | v0.8.0 | PIC Canonical JSON v1 spec (`docs/canonicalization.md`) + reference implementation (`pic_standard.canonical`), initial canonicalization + core conformance suite, conformance runner (`python -m conformance.run`), `PIC Conformance` CI job, refined attestation object draft with byte-level worked example | None — new capability added; existing proposals and signature verification paths unchanged. Canonicalization is not yet wired into evidence signing in v0.8.0. |
+| v0.8.1 | `PICSemiTrustedDeprecationWarning` for `provenance[].trust = "semi_trusted"`; canonical normalization at the model-validation boundary (pydantic field validator on `Provenance.trust`) with a bridge helper in `verify_proposal()` triggering it after JSON Schema validation; both deprecation-warning classes re-exported at package root; example files migrated off `semi_trusted`; verdict-regression matrix added as a permanent CI guard for the dict-vs-model boundary | None — schema enum unchanged in v0.8.1 (still accepts `"semi_trusted"`); runtime normalizes to `"untrusted"` at parse time. Wire format unchanged. Schema-level removal scheduled for v0.9.0. |
 
 The PIC/1.0 proposal structure and wire-level schema have remained stable since the RFC anchor. Post-RFC changes in v0.6.x–v0.8.x primarily affected shared pipeline behavior, trust resolution, integration surface, runtime efficiency, and canonicalization/conformance tooling rather than introducing a wire-format break.
 
-**Current Python reference implementation:** v0.8.0
+**Current Python reference implementation:** v0.8.1
 
 ---
 

--- a/examples/financial_irreversible.json
+++ b/examples/financial_irreversible.json
@@ -4,7 +4,7 @@
   "impact": "money",
   "provenance": [
     { "id": "cfo_signed_invoice_hash", "trust": "trusted" },
-    { "id": "slack_approval_manager", "trust": "semi_trusted" }
+    { "id": "slack_approval_manager", "trust": "untrusted" }
   ],
   "claims": [
     { "text": "Invoice hash matches authorized payment list", "evidence": ["cfo_signed_invoice_hash"] },

--- a/examples/robotic_action.json
+++ b/examples/robotic_action.json
@@ -4,7 +4,7 @@
   "impact": "irreversible",
   "provenance": [
     { "id": "lidar_safety_trigger", "trust": "trusted" },
-    { "id": "operator_voice_command", "trust": "semi_trusted" }
+    { "id": "operator_voice_command", "trust": "untrusted" }
   ],
   "claims": [
     { "text": "LIDAR detected obstacle within 0.5m hazard zone", "evidence": ["lidar_safety_trigger"] },

--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
     "id": "pic-guard",
     "name": "PIC Standard Guard",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "description": "Provenance & Intent Contract verification for OpenClaw tool calls",
     "configSchema": {
         "type": "object",

--- a/integrations/openclaw/package-lock.json
+++ b/integrations/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pic-guard",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pic-guard",
-            "version": "0.8.0",
+            "version": "0.8.1",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@types/node": "^20.19.32",

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pic-guard",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "description": "PIC Standard governance plugin for OpenClaw",
     "type": "module",
     "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pic-standard"
-version = "0.8.0"
+version = "0.8.1"
 description = "PIC Standard: Provenance & Intent Contracts for agentic side-effect governance"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk-python/pic_standard/__init__.py
+++ b/sdk-python/pic_standard/__init__.py
@@ -1,4 +1,18 @@
-from .verifier import ActionProposal, ImpactClass, TrustLevel
+from .verifier import (
+    ActionProposal,
+    ImpactClass,
+    TrustLevel,
+    PICSemiTrustedDeprecationWarning,
+)
 from .keyring import KeyResolver, StaticKeyRingResolver
+from .pipeline import PICTrustFutureWarning
 
-__all__ = ["ActionProposal", "ImpactClass", "TrustLevel", "KeyResolver", "StaticKeyRingResolver"]
+__all__ = [
+    "ActionProposal",
+    "ImpactClass",
+    "TrustLevel",
+    "KeyResolver",
+    "StaticKeyRingResolver",
+    "PICSemiTrustedDeprecationWarning",
+    "PICTrustFutureWarning",
+]

--- a/sdk-python/pic_standard/integrations/http_bridge.py
+++ b/sdk-python/pic_standard/integrations/http_bridge.py
@@ -17,7 +17,7 @@ GET  /health
     200:  {"status": "ok", "request_id": "<UUID>"}
 
 GET  /v1/version
-    200:  {"pic_version": "1.0", "package_version": "0.8.0", "commit": "<hash>", "policy_version": "1.0", "request_id": "<UUID>"}
+    200:  {"pic_version": "1.0", "package_version": "0.8.1", "commit": "<hash>", "policy_version": "1.0", "request_id": "<UUID>"}
 
 Design notes
 ------------

--- a/sdk-python/pic_standard/pipeline.py
+++ b/sdk-python/pic_standard/pipeline.py
@@ -24,7 +24,7 @@ from jsonschema import validate as js_validate
 
 from pic_standard.errors import PICError, PICErrorCode, _debug_enabled
 from pic_standard.policy import PICPolicy
-from pic_standard.verifier import ActionProposal
+from pic_standard.verifier import ActionProposal, Provenance
 
 # v0.3+ evidence (optional — graceful degradation when crypto not installed)
 try:
@@ -179,6 +179,79 @@ def _verify_tool_binding(
             message="Tool binding mismatch",
             details=details,
         )
+
+
+# ------------------------------------------------------------------
+# v0.8.1: Bridge to the model-validation boundary
+# ------------------------------------------------------------------
+#
+# pic_standard.verifier defines the canonical normalization boundary for
+# the deprecated 'semi_trusted' provenance trust value: a pydantic field
+# validator on Provenance.trust that emits PICSemiTrustedDeprecationWarning
+# and normalizes 'semi_trusted' -> 'untrusted' at construction time.
+#
+# The helper below triggers that validator on the raw proposal dict
+# immediately after JSON Schema validation and BEFORE strict-trust
+# flattening or evidence verification, so the warning fires regardless
+# of strict_trust mode and the dict consumed by downstream pipeline
+# steps is already normalized.
+#
+# Full ActionProposal instantiation still happens later in
+# verify_proposal() so verify_causal_contract observes the final
+# post-evidence-verification trust state.
+
+def _normalize_provenance_entries_via_model_validator(
+    proposal: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Trigger the Provenance.trust field validator on each provenance entry.
+
+    Emits PICSemiTrustedDeprecationWarning for any 'semi_trusted' entries and
+    normalizes them to 'untrusted' in the returned dict. Does not duplicate
+    normalization logic; only triggers the canonical validator at the right
+    point in the raw-dict pipeline.
+
+    Writeback uses a merge pattern: ``{**entry, "trust": pv.trust.value}``.
+    This is deliberate. ``Provenance`` currently models only ``id`` and
+    ``trust``; using ``pv.model_dump(...)`` would silently drop any extra
+    keys an entry may carry now or in the future (schema extensions,
+    annotations, attestation fields, etc.). The merge pattern keeps the
+    helper future-proof against forward-compatible extensions while still
+    letting the canonical validator be the only source of truth for the
+    ``trust`` value.
+
+    Returns a new dict; does not mutate the input. Malformed entries are
+    passed through unchanged so the main _instantiate_action_proposal step
+    can surface a precise error.
+    """
+    prov = proposal.get("provenance") or []
+    if not prov:
+        return proposal
+
+    new_prov: List[Any] = []
+    any_changed = False
+    for entry in prov:
+        if not isinstance(entry, dict):
+            new_prov.append(entry)
+            continue
+        try:
+            pv = Provenance.model_validate(entry)
+        except Exception:
+            # Defer to main instantiation, which produces the precise error.
+            new_prov.append(entry)
+            continue
+        normalized = {**entry, "trust": pv.trust.value}
+        # Narrower change-detection: this helper only ever rewrites `trust`,
+        # so check exactly that field rather than diffing the full dict.
+        if entry.get("trust") != pv.trust.value:
+            any_changed = True
+        new_prov.append(normalized)
+
+    if not any_changed:
+        return proposal
+
+    out = dict(proposal)
+    out["provenance"] = new_prov
+    return out
 
 
 # ------------------------------------------------------------------
@@ -364,14 +437,17 @@ def verify_proposal(
     Pipeline steps (in order):
       1.  Limits check (skip if ``options.limits`` is None)
       2.  JSON Schema validation
-      3.  Resolve impact (policy + proposal, falls back to expected_tool)
-      4.  Determine whether evidence verification will actually run
-      5.  Emit migration warning if legacy self-asserted trust would be accepted
-      6.  Build working proposal (sanitize trust when ``strict_trust=True``)
-      7.  Optional evidence verification + trust upgrade
-      8.  Final ``ActionProposal`` instantiation (pydantic + PIC rules)
-      9.  Tool binding via ``verify_with_context`` (skip if ``expected_tool`` is None)
-     10.  Time budget check
+      3.  Trigger Provenance field validator on each provenance entry
+          (v0.8.1+; emits PICSemiTrustedDeprecationWarning and normalizes
+          'semi_trusted' -> 'untrusted' before downstream pipeline steps)
+      4.  Resolve impact (policy + proposal, falls back to expected_tool)
+      5.  Determine whether evidence verification will actually run
+      6.  Emit migration warning if legacy self-asserted trust would be accepted
+      7.  Build working proposal (sanitize trust when ``strict_trust=True``)
+      8.  Optional evidence verification + trust upgrade
+      9.  Final ``ActionProposal`` instantiation (pydantic + PIC rules)
+     10.  Tool binding via ``verify_with_context`` (skip if ``expected_tool`` is None)
+     11.  Time budget check
 
     Returns ``PipelineResult`` — **never raises**.
     """
@@ -399,16 +475,24 @@ def verify_proposal(
                 message=f"PIC schema validation failed: {e.message}",
             ))
 
-        # 3. Resolve impact
+        # 3. Trigger model-validation boundary for deprecated provenance values (v0.8.1+)
+        # This fires Provenance.trust field validator on each entry, emitting
+        # PICSemiTrustedDeprecationWarning and normalizing 'semi_trusted' to
+        # 'untrusted' BEFORE strict-trust flattening or evidence verification.
+        # Full ActionProposal instantiation still happens at step 9 so
+        # verify_causal_contract observes the final post-evidence trust state.
+        proposal = _normalize_provenance_entries_via_model_validator(proposal)
+
+        # 4. Resolve impact
         impact = _resolve_impact(proposal, opts)
         tool_for_policy = opts.tool_name or opts.expected_tool
 
-        # 4. Determine whether evidence verification will actually run
+        # 5. Determine whether evidence verification will actually run
         should_verify, _ = _should_verify_evidence(
             proposal, impact=impact, opts=opts,
         )
 
-        # 5. Migration warning for legacy trust behavior (v0.8+)
+        # 6. Migration warning for legacy trust behavior (v0.8+)
         if _should_warn_on_self_asserted_trust(
             proposal, opts=opts, should_verify_evidence=should_verify,
         ):
@@ -425,12 +509,12 @@ def verify_proposal(
                 stacklevel=2,
             )
 
-        # 6. Build working proposal for this run
+        # 7. Build working proposal for this run
         working_proposal = (
             _sanitize_provenance_trust(proposal) if opts.strict_trust else proposal
         )
 
-        # 7. Optional evidence verification + trust upgrade
+        # 8. Optional evidence verification + trust upgrade
         evidence_report = None
         final_proposal = working_proposal
 
@@ -446,18 +530,18 @@ def verify_proposal(
             if upgraded is not None:
                 final_proposal = upgraded
 
-        # 8. Final semantic validation from finalized trust state
+        # 9. Final semantic validation from finalized trust state
         ap, err = _instantiate_action_proposal(final_proposal)
         if err is not None:
             return _fail(err, impact=impact)
 
-        # 9. Tool binding
+        # 10. Tool binding
         if opts.expected_tool is not None:
             bind_err = _verify_tool_binding(ap, opts.expected_tool)  # type: ignore[arg-type]
             if bind_err is not None:
                 return _fail(bind_err, impact=impact)
 
-        # 10. Time budget check (effective budget: explicit > limits.max_eval_ms)
+        # 11. Time budget check (effective budget: explicit > limits.max_eval_ms)
         eval_ms = _elapsed_ms()
         effective_budget_ms = opts.time_budget_ms
         if effective_budget_ms is None and opts.limits is not None:

--- a/sdk-python/pic_standard/verifier.py
+++ b/sdk-python/pic_standard/verifier.py
@@ -1,9 +1,30 @@
 from __future__ import annotations
 
+import warnings
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, field_validator, model_validator
+
+
+# ------------------------------------------------------------------
+# v0.8.1: semi_trusted deprecation warning
+# ------------------------------------------------------------------
+
+class PICSemiTrustedDeprecationWarning(FutureWarning):
+    """Emitted when a Provenance entry is constructed with trust='semi_trusted'.
+
+    The 'semi_trusted' value is deprecated in v0.8.1 and will be removed from
+    the proposal schema and TrustLevel enum in v0.9.0. The pydantic field
+    validator on Provenance.trust normalizes the value to 'untrusted' at
+    construction time and emits this warning, in all modes (not only
+    strict_trust=True).
+
+    Producers should migrate to trust='untrusted' and attach verifiable
+    evidence; verifiers derive effective trust from successful evidence
+    verification per the trust axiom (v0.7.5).
+    """
+    pass
 
 
 class TrustLevel(str, Enum):
@@ -25,6 +46,33 @@ class ImpactClass(str, Enum):
 class Provenance(BaseModel):
     id: str
     trust: TrustLevel
+
+    @field_validator("trust", mode="before")
+    @classmethod
+    def _normalize_semi_trusted(cls, v: Any) -> Any:
+        """Canonical normalization boundary for the deprecated 'semi_trusted' value.
+
+        Fires at Provenance construction time, in all modes. Any path that bypasses
+        this validator is non-conformant with the v0.8.1 behavior contract.
+
+        Detects 'semi_trusted' as either the raw string or the TrustLevel enum
+        member (TrustLevel is a str-Enum, so equality unifies both forms).
+        Emits PICSemiTrustedDeprecationWarning and returns TrustLevel.UNTRUSTED;
+        all other values pass through unchanged for pydantic to coerce normally.
+        """
+        if v == "semi_trusted":
+            warnings.warn(
+                "PIC deprecation: provenance trust='semi_trusted' is "
+                "deprecated in v0.8.1 and will be removed in v0.9.0. "
+                "Normalizing to 'untrusted'. Producers should migrate "
+                "to trust='untrusted' with verifiable evidence; "
+                "verifiers derive effective trust from evidence per the "
+                "trust axiom. See docs/migration-trust-sanitization.md.",
+                PICSemiTrustedDeprecationWarning,
+                stacklevel=2,
+            )
+            return TrustLevel.UNTRUSTED
+        return v
 
 
 class Claim(BaseModel):

--- a/tests/test_trust_deprecation_warning.py
+++ b/tests/test_trust_deprecation_warning.py
@@ -1,8 +1,24 @@
-"""Tests for PIC v0.8 trust deprecation warning (PICTrustFutureWarning)."""
+"""Tests for PIC v0.8.x trust deprecation warnings.
+
+Covers two warning surfaces:
+
+- ``PICTrustFutureWarning`` (v0.7.5): self-asserted ``trust='trusted'``
+  under non-strict mode where evidence verification will not actually run.
+
+- ``PICSemiTrustedDeprecationWarning`` (v0.8.1): inbound
+  ``trust='semi_trusted'`` is deprecated; canonical normalization is the
+  ``Provenance.trust`` field validator in ``pic_standard.verifier``.
+
+Plus a verdict-regression matrix that pins v0.8.0 baseline outcomes for
+representative example proposals, so any future refactor that touches the
+dict-vs-model boundary surfaces immediately as a CI failure.
+"""
 
 from __future__ import annotations
 
+import json
 import warnings
+from pathlib import Path
 
 import pytest
 
@@ -11,6 +27,12 @@ from pic_standard.pipeline import (
     PICTrustFutureWarning,
     PipelineOptions,
     verify_proposal,
+)
+from pic_standard.verifier import (
+    ActionProposal,
+    PICSemiTrustedDeprecationWarning,
+    Provenance,
+    TrustLevel,
 )
 
 from conftest import make_proposal
@@ -89,7 +111,12 @@ class TestTrustFutureWarning:
         assert not pic_warnings
 
     def test_no_warning_for_semi_trusted(self) -> None:
-        """trust='semi_trusted' → no warning (only 'trusted' triggers)."""
+        """trust='semi_trusted' → no PICTrustFutureWarning (only 'trusted' triggers).
+
+        Note: PICSemiTrustedDeprecationWarning DOES fire for semi_trusted under
+        v0.8.1+ (covered by TestSemiTrustedDeprecationWarning below). This test
+        only asserts the absence of the OTHER warning class.
+        """
         proposal = make_proposal(
             trust="semi_trusted", impact="read",
             tool="docs_search", intent="Search docs",
@@ -130,3 +157,276 @@ class TestTrustFutureWarning:
         assert "verifiable evidence" in msg
         assert "strict_trust=True" in msg
         assert "migration-trust-sanitization.md" in msg
+
+
+# ============================================================================
+# v0.8.1: PICSemiTrustedDeprecationWarning
+# ============================================================================
+
+class TestSemiTrustedDeprecationWarning:
+    """PICSemiTrustedDeprecationWarning fires when a Provenance entry is
+    constructed with trust='semi_trusted'.
+
+    The pydantic field validator on Provenance.trust is the canonical
+    normalization boundary for v0.8.1+: it warns + normalizes the value
+    to TrustLevel.UNTRUSTED at construction time, in all modes.
+    """
+
+    def test_warning_fires_on_direct_construction_string_form(self) -> None:
+        """Provenance(trust='semi_trusted') as raw string → warns + normalizes."""
+        with pytest.warns(PICSemiTrustedDeprecationWarning):
+            p = Provenance(id="x", trust="semi_trusted")
+        assert p.trust == TrustLevel.UNTRUSTED
+
+    def test_warning_fires_on_direct_construction_enum_form(self) -> None:
+        """Provenance(trust=TrustLevel.SEMI_TRUSTED) as enum → warns + normalizes.
+
+        TrustLevel is a str-Enum, so equality unifies string and enum forms.
+        """
+        with pytest.warns(PICSemiTrustedDeprecationWarning):
+            p = Provenance(id="x", trust=TrustLevel.SEMI_TRUSTED)
+        assert p.trust == TrustLevel.UNTRUSTED
+
+    def test_warning_cascades_through_action_proposal_per_entry(self) -> None:
+        """Constructing ActionProposal with N semi_trusted entries fires N warnings
+        (one per Provenance instance — the field-validator fires per-instance,
+        not once-per-proposal)."""
+        proposal_dict = {
+            "protocol": "PIC/1.0",
+            "intent": "x",
+            "impact": "read",
+            "provenance": [
+                {"id": "a", "trust": "semi_trusted"},
+                {"id": "b", "trust": "semi_trusted"},
+            ],
+            "claims": [{"text": "x", "evidence": ["a"]}],
+            "action": {"tool": "t", "args": {}},
+        }
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ap = ActionProposal(**proposal_dict)
+        semi = [w for w in caught if issubclass(w.category, PICSemiTrustedDeprecationWarning)]
+        assert len(semi) == 2  # one warning per semi_trusted entry
+        assert all(p.trust == TrustLevel.UNTRUSTED for p in ap.provenance)
+
+    def test_verify_proposal_non_strict_fires_warning_and_normalizes(self) -> None:
+        """Non-strict mode: bridge helper triggers validator, warning fires,
+        semi_trusted -> untrusted, existing verdict behavior preserved."""
+        proposal = make_proposal(
+            trust="semi_trusted", impact="read",
+            tool="docs_search", intent="search",
+        )
+        with pytest.warns(PICSemiTrustedDeprecationWarning):
+            r = verify_proposal(proposal, options=PipelineOptions(strict_trust=False))
+        assert r.ok  # low impact, normalization to untrusted is fine
+
+    def test_verify_proposal_strict_trust_still_fires_warning(self) -> None:
+        """Strict mode: warning STILL fires because the bridge helper runs BEFORE
+        strict-trust flattening. This is the load-bearing Path A property — the
+        whole reason the pipeline triggers the validator early instead of relying
+        on full ActionProposal instantiation alone."""
+        proposal = make_proposal(
+            trust="semi_trusted", impact="read",
+            tool="docs_search", intent="search",
+        )
+        with pytest.warns(PICSemiTrustedDeprecationWarning):
+            r = verify_proposal(proposal, options=PipelineOptions(strict_trust=True))
+        assert r.ok  # low impact
+
+    def test_mixed_provenance_only_fires_for_semi_trusted_entries(self) -> None:
+        """Proposal with one trusted, one semi_trusted, one untrusted entry:
+        exactly one PICSemiTrustedDeprecationWarning fires (for the single
+        semi_trusted entry); trusted and untrusted pass through unchanged."""
+        proposal = make_proposal(
+            trust="trusted", impact="read",
+            tool="docs_search", intent="search",
+            extra_provenance=[
+                {"id": "p2", "trust": "semi_trusted"},
+                {"id": "p3", "trust": "untrusted"},
+            ],
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            verify_proposal(proposal, options=PipelineOptions(strict_trust=False))
+        semi = [w for w in caught if issubclass(w.category, PICSemiTrustedDeprecationWarning)]
+        assert len(semi) == 1
+
+    def test_no_warning_when_no_semi_trusted_present(self) -> None:
+        """Regression guard: no semi_trusted -> no PICSemiTrustedDeprecationWarning."""
+        proposal = make_proposal(
+            trust="untrusted", impact="read",
+            tool="docs_search", intent="search",
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            verify_proposal(proposal, options=PipelineOptions(strict_trust=False))
+        semi = [w for w in caught if issubclass(w.category, PICSemiTrustedDeprecationWarning)]
+        assert not semi
+
+    def test_warning_message_contains_migration_guidance(self) -> None:
+        """Warning text mentions key migration concepts."""
+        with pytest.warns(PICSemiTrustedDeprecationWarning) as record:
+            Provenance(id="x", trust="semi_trusted")
+        assert len(record) == 1
+        msg = str(record[0].message)
+        assert "deprecated in v0.8.1" in msg
+        assert "v0.9.0" in msg
+        assert "migration-trust-sanitization.md" in msg
+
+
+class TestPICTrustFutureWarningStillWorksAfterRefactor:
+    """Regression guard: PICTrustFutureWarning behavior is unchanged after
+    v0.8.1's bridge-helper insertion. The two warnings are independent
+    (different layers, different conditions)."""
+
+    def test_self_asserted_trusted_still_warns_after_v081_refactor(self) -> None:
+        """The existing self-asserted 'trusted' + no-evidence warning still fires
+        after the v0.8.1 bridge helper was inserted. The bridge only normalizes
+        semi_trusted; it does not interfere with the trusted-flow warning logic."""
+        proposal = make_proposal(trust="trusted", impact="money")
+        with pytest.warns(PICTrustFutureWarning):
+            r = verify_proposal(
+                proposal,
+                options=PipelineOptions(verify_evidence=False, strict_trust=False),
+            )
+        assert r.ok
+
+
+# ============================================================================
+# v0.8.1: Verdict-regression matrix (codified, parametrized)
+# ============================================================================
+#
+# Permanent CI guard against any future refactor that touches the dict-vs-model
+# boundary in pipeline.verify_proposal(). Asserts only the STABLE verdict-bearing
+# fields of PipelineResult — `ok` (bool) and, when ok=False, `error.code`
+# compared against a PICErrorCode enum member. Does NOT assert on
+# `error.message`, `impact`, `eval_ms`, or other unstable fields. Does NOT
+# compare against the enum's `.value` string — the enum member is the stable
+# API; `.value` is an implementation detail.
+#
+# Expected baseline values are HARDCODED LITERALS (enum members for error
+# codes; bool / None for verdicts) captured at v0.8.1 design time from the
+# v0.8.0 baseline behavior. They are NOT derived at test time by calling
+# verify_proposal() or any helper that shares a code path with the system
+# under test — that would defeat the guard's purpose (the test would just
+# assert that the current behavior matches the current behavior).
+#
+# Excluded: financial_sig_ok.json — its verify_evidence=True path requires
+# keyring environment setup (PIC_KEYS_PATH or explicit key_resolver) and would
+# make the regression matrix brittle. Sig-flow regression is covered by
+# dedicated sig tests elsewhere in the suite.
+
+EXAMPLES_DIR = Path(__file__).resolve().parent.parent / "examples"
+
+
+# (filename, strict_trust, verify_evidence, expected_ok, expected_error_code_or_None)
+VERDICT_REGRESSION_MATRIX: list[tuple[str, bool, bool, bool, PICErrorCode | None]] = [
+    # Low-impact: always allowed regardless of trust
+    ("compute_risk.json",            False, False, True,  None),
+    ("compute_risk.json",            False, True,  True,  None),
+    ("compute_risk.json",            True,  False, True,  None),
+    ("compute_risk.json",            True,  True,  True,  None),
+    ("read_only_query.json",         False, False, True,  None),
+    ("read_only_query.json",         False, True,  True,  None),
+    ("read_only_query.json",         True,  False, True,  None),
+    ("read_only_query.json",         True,  True,  True,  None),
+
+    # CANARY for "did instantiation move ahead of evidence verification?".
+    # financial_hash_ok.json has high-impact (money) + untrusted provenance +
+    # hash evidence. With verify_evidence=True the hash must verify and upgrade
+    # trust to trusted BEFORE the contract check sees the model. If any future
+    # refactor moves full ActionProposal instantiation ahead of evidence
+    # verification, these two ok=True rows flip to ok=False — the test fails
+    # immediately and points at the regression.
+    ("financial_hash_ok.json",       False, False, False, PICErrorCode.VERIFIER_FAILED),
+    ("financial_hash_ok.json",       False, True,  True,  None),                          # canary
+    ("financial_hash_ok.json",       True,  False, False, PICErrorCode.VERIFIER_FAILED),
+    ("financial_hash_ok.json",       True,  True,  True,  None),                          # canary (strict mode)
+
+    # High-impact (money). Has cfo_signed_invoice_hash:trusted as load-bearing
+    # entry. Non-strict: contract satisfied. Strict: all flattened to untrusted,
+    # contract fails.
+    ("financial_irreversible.json",  False, False, True,  None),
+    ("financial_irreversible.json",  False, True,  True,  None),
+    ("financial_irreversible.json",  True,  False, False, PICErrorCode.VERIFIER_FAILED),
+    ("financial_irreversible.json",  True,  True,  False, PICErrorCode.VERIFIER_FAILED),
+
+    # High-impact (privacy) with user_email_consent:trusted.
+    ("privacy_risk.json",            False, False, True,  None),
+    ("privacy_risk.json",            False, True,  True,  None),
+    ("privacy_risk.json",            True,  False, False, PICErrorCode.VERIFIER_FAILED),
+    ("privacy_risk.json",            True,  True,  False, PICErrorCode.VERIFIER_FAILED),
+
+    # High-impact (irreversible) with lidar_safety_trigger:trusted as load-bearing.
+    ("robotic_action.json",          False, False, True,  None),
+    ("robotic_action.json",          False, True,  True,  None),
+    ("robotic_action.json",          True,  False, False, PICErrorCode.VERIFIER_FAILED),
+    ("robotic_action.json",          True,  True,  False, PICErrorCode.VERIFIER_FAILED),
+]
+
+
+@pytest.mark.parametrize(
+    "filename,strict_trust,verify_evidence,expected_ok,expected_error_code",
+    VERDICT_REGRESSION_MATRIX,
+)
+def test_verdict_regression_matrix(
+    filename: str,
+    strict_trust: bool,
+    verify_evidence: bool,
+    expected_ok: bool,
+    expected_error_code: PICErrorCode | None,
+) -> None:
+    """Pins v0.8.0 baseline outcomes for representative example proposals.
+
+    Asserts only the stable verdict-bearing fields. See module-level matrix
+    comment for the design rationale.
+    """
+    proposal = json.loads((EXAMPLES_DIR / filename).read_text(encoding="utf-8"))
+
+    # Suppress deprecation warnings — they fire for some examples (semi_trusted
+    # in financial_irreversible/robotic_action pre-migration; PICTrustFutureWarning
+    # for self-asserted trusted entries). The matrix asserts verdicts, not
+    # warning emission. Warning emission is covered by the dedicated tests above.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = verify_proposal(
+            proposal,
+            options=PipelineOptions(
+                strict_trust=strict_trust,
+                verify_evidence=verify_evidence,
+                proposal_base_dir=EXAMPLES_DIR,
+                evidence_root_dir=EXAMPLES_DIR,
+            ),
+        )
+
+    assert result.ok is expected_ok, (
+        f"verdict regression: {filename} "
+        f"(strict_trust={strict_trust}, verify_evidence={verify_evidence}) "
+        f"returned ok={result.ok}, expected ok={expected_ok}"
+    )
+    if not expected_ok:
+        assert result.error is not None
+        assert result.error.code == expected_error_code, (
+            f"error.code regression: {filename} returned "
+            f"{result.error.code!r}, expected {expected_error_code!r}"
+        )
+
+
+# ============================================================================
+# v0.8.1: Public API surface — package-root re-export pin
+# ============================================================================
+
+class TestPublicAPISurface:
+    """Pins v0.8.1's package-root re-export of both deprecation warning classes.
+
+    Future refactors that touch ``sdk-python/pic_standard/__init__.py`` cannot
+    silently drop these re-exports without this test failing.
+    """
+
+    def test_deprecation_warnings_importable_at_package_root(self) -> None:
+        from pic_standard import (
+            PICSemiTrustedDeprecationWarning as PicSemi,
+            PICTrustFutureWarning as PicTrust,
+        )
+        assert issubclass(PicSemi, FutureWarning)
+        assert issubclass(PicTrust, FutureWarning)


### PR DESCRIPTION
## Summary

v0.8.1 — first protocol-touching release after Phase 0 hygiene. Single behavior change: **deprecate `provenance[].trust == "semi_trusted"`** with a `PICSemiTrustedDeprecationWarning` at the canonical model-validation boundary. Schema enum unchanged in v0.8.1; **schema-level removal scheduled for v0.9.0**.

The canonical normalization boundary is the pydantic field validator on `Provenance.trust` in `pic_standard.verifier`. `verify_proposal()` triggers it via a small bridge helper immediately after JSON Schema validation, so warnings fire and `semi_trusted` is normalized to `"untrusted"` regardless of `strict_trust` mode and before strict-trust flattening or evidence verification consume the dict. **Full `ActionProposal` instantiation stays last** so `verify_causal_contract` keeps observing post-evidence trust state — the existing `untrusted -> evidence verified -> trusted` upgrade path is unaffected.

## What ships

**Code:**
- `sdk-python/pic_standard/verifier.py` — `PICSemiTrustedDeprecationWarning(FutureWarning)` class + `Provenance.trust` field validator (mode='before')
- `sdk-python/pic_standard/__init__.py` — both deprecation-warning classes re-exported at package root (import-cycle check passed during execution)
- `sdk-python/pic_standard/pipeline.py` — bridge helper `_normalize_provenance_entries_via_model_validator()`; pipeline step list grows from 10 to 11 (new step 3 between schema validation and impact resolution)
- `tests/test_trust_deprecation_warning.py` — 8 new `TestSemiTrustedDeprecationWarning` tests, 1 `TestPICTrustFutureWarningStillWorksAfterRefactor`, parametrized verdict-regression matrix (24 rows × 6 examples × strict_trust × verify_evidence) asserting only stable fields (`ok` + `error.code` enum), 1 `TestPublicAPISurface` re-export pin

**Examples:**
- `examples/financial_irreversible.json` + `examples/robotic_action.json` — migrated off `trust: "semi_trusted"` to `trust: "untrusted"`. Trust-flip only; no hash evidence added (hash binds bytes, not authority — adding it would teach the wrong intuition given that PIC's evidence flow upgrades trust on hash verification). The load-bearing `"trusted"` provenance entries (`cfo_signed_invoice_hash`, `lidar_safety_trigger`) are unchanged.

**Docs:**
- `docs/migration-trust-sanitization.md` — Timeline gains v0.8.1 row; `semi_trusted` Q&A flipped from "(planned)" to "(this release)" tense; example file migration noted explicitly
- `CHANGELOG.md` — new `[0.8.1]` entry with Added / Deprecated / Changed / Notes sections
- `ROADMAP.md` — Phase 0 marked Done (PR #67); v0.8.1 marked Done; remaining v0.8.1-targeted items (conformance expansion, runner hardening, initial DRAFTs of `spec-core.md` / `spec-evidence.md`) deferred to v0.8.2 to keep this release focused on the deprecation surface
- `docs/spec-status.md` — new v0.8.1 row in the change-since-RFC-anchor table; "Current Python reference implementation" bumped to v0.8.1

**Version bump (0.8.0 → 0.8.1):**
- `pyproject.toml`, `integrations/openclaw/package.json`, `integrations/openclaw/openclaw.plugin.json`, `integrations/openclaw/package-lock.json` (2 occurrences), `sdk-python/pic_standard/integrations/http_bridge.py` (docstring example), `SECURITY.md` (example version in advisory-form guidance)

**NOT in this PR (intentional):**
- `CITATION.cff` — bumped as a separate follow-up commit on `main` after release day, with the actual `date-released` and (if Zenodo archives by then) the v0.8.1 version DOI

## Why now

ROADMAP committed `semi_trusted` Path B in Phase 0: deprecate v0.8.1, remove v0.9.0. v0.8.1 is the first protocol-touching release after Phase 0 hygiene; this PR ships the deprecation half of that trajectory. v0.9.0 will ship the removal half.

## Verification checklist

- [x] **Tests pass:** `pytest tests/ -v` (full suite minus the langgraph-extra integration tests which require `langchain_core` install — not a v0.8.1 regression). **237 passed, 0 failed.**
- [x] **Conformance:** `python -m conformance.run` — **13/13 vectors pass.** No conformance manifest changes.
- [x] **Verdict-regression matrix passes:** the new parametrized test in `tests/test_trust_deprecation_warning.py` (24 rows) asserts that v0.8.0 baseline outcomes are preserved across the `strict_trust × verify_evidence` matrix for 6 representative example proposals. Hardcoded literals; not derived at test time. Includes the `financial_hash_ok.json` + `verify_evidence=True` canary that would flip `ok=True → ok=False` if any future refactor moved full instantiation ahead of evidence verification.
- [x] **Smoke test:** crafted ad-hoc proposals with `semi_trusted` confirm `PICSemiTrustedDeprecationWarning` fires correctly under both `strict_trust=False` and `strict_trust=True` (the load-bearing Path A property — bridge helper runs before strict-trust flattening).
- [ ] **CI checks (will run on push):** `ci.yml` workflows + `conformance.yml` `PIC Conformance` job. Expecting 12+ green checks.

## Architecture decision: why a bridge helper instead of moving instantiation earlier

During execution we discovered that the originally-planned approach (move full `ActionProposal` instantiation ahead of strict-trust sanitization and evidence verification) would have caused unintended verdict regression for high-impact + evidence-upgrade flows. `verify_causal_contract` is a `@model_validator` that fires at instantiation time and enforces high-impact-trusted-evidence; if instantiation moves before evidence verification, hash-evidence-backed proposals fail at instantiation before evidence has a chance to upgrade trust to `trusted`.

So v0.8.1 keeps the existing pipeline order intact and adds a small bridge helper that triggers ONLY the `Provenance.trust` field validator (not full `ActionProposal` instantiation) immediately after JSON Schema validation. This fires the deprecation warning + normalizes `semi_trusted` early, while leaving full instantiation last so contract enforcement keeps observing the final post-evidence trust state.

The verdict-regression matrix codifies this invariant as a permanent CI guard against future refactors.

## Out of scope

- No `pyproject.toml` API surface changes beyond the version bump
- No `proposal_schema.json` changes (`semi_trusted` stays in the enum until v0.9.0)
- No `conformance/manifest.json` changes
- No `.github/workflows/*` changes
- No CITATION.cff in this PR (release-day follow-up)

## Follow-ups (post-merge)

- Tag `v0.8.1`, build wheel + sdist, `twine upload dist/*`, GitHub release
- Tiny follow-up commit on `main`: `CITATION.cff` to v0.8.1 + actual release date + (if Zenodo archives) v0.8.1 version DOI