### PR TITLE
chore: update CITATION.cff for v0.8.1 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,16 +13,16 @@ url: "https://github.com/madeinplutofabio/pic-standard"
 repository-artifact: "https://pypi.org/project/pic-standard/"
 license: "Apache-2.0"
 
-version: "0.8.0"
-date-released: "2026-04-20"
+version: "0.8.1"
+date-released: "2026-05-07"
 
 identifiers:
   - type: doi
     value: "10.5281/zenodo.18725562"
     description: "Concept DOI (umbrella; resolves to the latest archived version)"
   - type: doi
-    value: "10.5281/zenodo.19683522"
-    description: "Version DOI for v0.8.0 (archived 2026-04-21)"
+    value: "10.5281/zenodo.20072579"
+    description: "Version DOI for v0.8.1 (archived 2026-05-07)"
 
 keywords:
   - ai-safety


### PR DESCRIPTION
Post-release metadata bump for v0.8.1.

- `version: 0.8.0 -> 0.8.1`
- `date-released: 2026-04-20 -> 2026-05-07` (actual PyPI upload day)
- v0.8.0 version DOI replaced with v0.8.1 version DOI `10.5281/zenodo.20072579` (Zenodo archived v0.8.1 the same day as the GitHub release; concept DOI `10.5281/zenodo.18725562` unchanged)

This is the post-release-day follow-up explicitly decoupled from PR #68 per the v0.8.1 plan: CITATION metadata is set on release day with the actual upload date, not at main-PR construction time, to avoid baking fictional release dates into the file.