### PR TITLE
chore: OpenSSF Passing - release signing infrastructure

### DIFF
--- a/.github/release-signing-key.pub
+++ b/.github/release-signing-key.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDhoOQt2X+irvPwMj1zRuCAIhdH0kV3nKFiQzHLx/luS PIC Standard release signing key (madeinplutofabio)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,166 @@
+# Release workflow for pic-standard.
+#
+# Triggered by tag pushes matching `v*`. Maintainer flow:
+#   git tag -s v<version> -m "..."
+#   git push origin v<version>
+#
+# This workflow:
+#   1. Verifies the tag's SSH signature against the trusted release-signing
+#      key committed at .github/release-signing-key.pub. Aborts if unsigned
+#      or signed by an unknown key.
+#   2. Builds wheel + sdist via `python -m build`.
+#   3. Publishes to PyPI via `pypa/gh-action-pypi-publish` using Trusted
+#      Publisher (no API token) and auto-generates PEP 740 attestations.
+#   4. Creates the GitHub Release with the annotated tag's subject + body
+#      as release notes (signature block excluded), attaching the built
+#      wheel + sdist as assets.
+#
+# The `pypi` environment (configured under repo Settings → Environments)
+# provides an approval gate — a maintainer must explicitly approve each
+# publish run in the Actions UI before any artifact reaches PyPI.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+# Workflow-wide default: minimal read access. Each job elevates explicitly.
+permissions:
+  contents: read
+
+jobs:
+  # ──────────────────────────────────────────────────────────────────
+  # Verify the tag is signed by the trusted release-signing key, then
+  # build the distribution artifacts. Runs immediately on tag push.
+  # NO approval gate — this is the precondition that decides whether
+  # the approval gate even fires in the publish job.
+  # ──────────────────────────────────────────────────────────────────
+  verify-and-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history + tags so `git tag -v` can read the annotated
+          # tag's signature payload.
+          fetch-depth: 0
+
+      - name: Verify tag signature against trusted public key
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          # Construct the allowed_signers policy from the committed public
+          # key. This is the trust anchor — only signatures from the exact
+          # key in .github/release-signing-key.pub are accepted.
+          mkdir -p ~/.ssh
+          KEY_CONTENT=$(cat .github/release-signing-key.pub)
+          echo "fabio@madeinpluto.com $KEY_CONTENT" > ~/.ssh/release-allowed-signers
+
+          # Tell git to verify SSH-format signatures using that policy.
+          git config gpg.format ssh
+          git config gpg.ssh.allowedSignersFile ~/.ssh/release-allowed-signers
+
+          # Verify. Exits non-zero on:
+          #  - unsigned tag
+          #  - signed by a key not in allowed_signers
+          #  - corrupt signature
+          # Workflow aborts here if any check fails — no artifact builds.
+          git tag -v "$TAG"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+
+      - name: Build wheel + sdist
+        run: python -m build
+
+      - name: Upload build artifacts for publish job
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 7
+          if-no-files-found: error
+
+  # ──────────────────────────────────────────────────────────────────
+  # Publish to PyPI (Trusted Publisher + PEP 740 attestations) and
+  # create the GitHub Release. Gated by the `pypi` environment, which
+  # requires maintainer approval before this job runs.
+  # ──────────────────────────────────────────────────────────────────
+  publish:
+    needs: verify-and-build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/project/pic-standard/
+
+    permissions:
+      # OIDC token for Trusted Publisher authentication + PEP 740 attestation
+      # generation. The PyPA action exchanges this token with PyPI for an
+      # ephemeral upload credential.
+      id-token: write
+      # Required for softprops/action-gh-release@v2 to create the Release
+      # and attach assets.
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Needed for the annotated-tag-body extraction step below.
+          fetch-depth: 0
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI (Trusted Publisher + attestations)
+        # Pinned to the PyPA-recommended @release/v1 floating major;
+        # auto-generates and uploads PEP 740 attestations by default
+        # (no extra config needed). Trust is established by PyPI's
+        # Trusted Publisher policy: project `pic-standard`, workflow
+        # `release.yml`, environment `pypi`.
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Extract annotated tag message for release notes
+        id: tag-body
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          # Read subject + body of the annotated tag, EXCLUDING the
+          # signature block. `%(contents)` would include the
+          # "-----BEGIN SSH SIGNATURE-----" trailer — visually wrong
+          # for release notes. Use `%(contents:body)` (body only) and
+          # `%(subject)` (first line), then emit them in standard
+          # subject + blank-line + body shape.
+          git tag --list --format=$'%(subject)%(if)%(contents:body)%(then)\n\n%(contents:body)%(end)' "$TAG" > release-body.md
+          echo "body-path=release-body.md" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          # Use the annotated tag's subject + body (no signature block).
+          body_path: ${{ steps.tag-body.outputs.body-path }}
+          # Attach the built wheel + sdist as release assets — handy for
+          # reproducibility (anyone can grab the exact wheel without
+          # going through PyPI's interface).
+          files: dist/*
+          # Prerelease detection from semver convention: if the tag has a
+          # pre-release suffix (e.g., `v1.0.0-rc1`, `v1.0.0-beta.2`), the
+          # tag name contains `-` and we mark it as prerelease.
+          # `make_latest` is intentionally omitted — softprops uses its
+          # default behavior, which marks stable tags as latest and skips
+          # "latest" for prereleases.
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,5 +60,17 @@ corresponding tests.
 ## ⚖️ Governance Model
 The PIC Standard is consensus-driven. Major changes to the core `spec/` or `schemas/` must be initiated in the **GitHub Discussions** tab before a Pull Request is opened.
 
+## 🔑 Release Process
+
+**All release tags MUST be signed** with the project's dedicated SSH release-signing key. This is not just policy — the release workflow (`.github/workflows/release.yml`) verifies the tag's signature against the trusted public key in `.github/release-signing-key.pub` before any artifact is built. Unsigned or wrongly-signed tags are rejected; no PyPI upload or GitHub Release happens for them.
+
+Full setup and release flow:
+
+- Signing key generation, git config, GitHub Signing Key registration: see `RELEASING.md` (Prerequisites section).
+- Release flow (`git tag -s` → push → approval gate → automated publish): see `RELEASING.md` (For maintainers section).
+- Trusted public key + SHA256 fingerprint: see `RELEASING.md` (Trusted public signing key section).
+
+New maintainers should complete the one-time setup before cutting their first release.
+
 ## 📜 Code of Conduct
 Please be professional and inclusive. We follow the Contributor Covenant.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/pic-standard.svg?logo=pypi&logoColor=white)](https://pypi.org/project/pic-standard/)
 [![PyPI downloads](https://img.shields.io/pypi/dm/pic-standard.svg?logo=pypi&logoColor=white)](https://pypi.org/project/pic-standard/)
+[![Signed releases](https://img.shields.io/badge/signed%20releases-Sigstore%20%2B%20SSH-brightgreen)](https://github.com/madeinplutofabio/pic-standard/blob/main/RELEASING.md)
 [![CI](https://github.com/madeinplutofabio/pic-standard/actions/workflows/ci.yml/badge.svg)](https://github.com/madeinplutofabio/pic-standard/actions/workflows/ci.yml)
 [![Code style: Ruff](https://img.shields.io/badge/code%20style-ruff-D7FF64)](https://docs.astral.sh/ruff/)
 [![Coverage](https://img.shields.io/badge/coverage-%E2%89%A580%25-brightgreen)](https://github.com/madeinplutofabio/pic-standard/blob/main/pyproject.toml)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,264 @@
+# Releasing pic-standard
+
+This document describes how releases of `pic-standard` are produced, signed, and verified.
+
+It is intended for two audiences:
+
+- **Maintainers** who cut releases. The flow is `git tag -s` → `git push` → maintainer-approves the deploy → PyPI + GitHub Release are produced automatically.
+- **Users and downstream consumers** who want to verify cryptographically that a release artifact (PyPI wheel/sdist or git tag) was produced by the project's authorized release pipeline.
+
+---
+
+## Trust model: two cryptographically-verifiable layers
+
+The release pipeline produces two distinct signed artifacts, verifiable through two distinct paths:
+
+### Layer 1: PyPI distribution artifacts (wheel + sdist)
+
+Built and uploaded to PyPI by `.github/workflows/release.yml`. Each upload is accompanied by a **PEP 740 attestation** — a Sigstore-issued, transparency-logged signature binding the artifact bytes to a specific GitHub Actions workflow identity (`madeinplutofabio/pic-standard`, workflow `release.yml`, environment `pypi`).
+
+- **What proves authenticity:** PyPI publishes the attestation alongside the artifact. The Sigstore-issued certificate is short-lived (per-workflow-run, ephemeral) but cryptographically tied to a GitHub Actions OIDC token claim that asserts "this workflow ran in this repo from this environment." Trust roots back to GitHub's OIDC issuer + Sigstore's public transparency log.
+- **What you do to verify:** install `pypi-attestations` (a FLOSS CLI from PyPA), point it at the artifact, and the tool fetches the attestation from PyPI and validates the entire chain. See "For users" below for the command.
+- **No long-lived artifact-signing public key.** This is the modern PEP 740 model: ephemeral keys per workflow run, anchored by GitHub identity + Sigstore.
+
+### Layer 2: Git tags
+
+Created locally by the maintainer using `git tag -s`, signed with the project's dedicated **long-lived SSH release-signing key** (Ed25519). The public half is published in this repository at `.github/release-signing-key.pub` and pinned in this document.
+
+- **What proves authenticity:** the tag carries an OpenSSH signature over the tag's metadata. Verification compares the signature against the published public key; if they match, the tag was signed by whoever holds the corresponding private key (the maintainer).
+- **What you do to verify:** download the published public key, populate a local `allowed_signers` file, and run `git tag -v <tag-name>`. GitHub also auto-displays a "Verified" indicator on signed tags in the Releases → Tags view (server-side check against the maintainer's registered Signing Key).
+- **Classic long-lived key model.** The same public key is reused across all releases until explicit rotation (see "Key rotation" below).
+
+Both layers run for every release. If either verification fails, treat the release as **unverified** until the discrepancy is resolved.
+
+---
+
+## For maintainers
+
+### Cutting a release
+
+From a clean checkout of `main` at the commit you want to release:
+
+```bash
+# 1. Create an annotated, signed tag. `git tag -s` automatically signs with
+#    the SSH release-signing key (per the repo's git config — see Prerequisites).
+#    The -m message becomes the GitHub Release body (release notes).
+git tag -s v<version> -m "v<version>: <human-readable release notes>
+
+<longer body, multi-line OK>"
+
+# 2. Push the tag. This triggers .github/workflows/release.yml.
+git push origin v<version>
+```
+
+The annotated tag's message is used **verbatim** as the GitHub Release body. Write release notes that humans can read — change summary, breaking changes, migration notes, etc. Do not paste raw commit logs.
+
+### What happens after `git push`
+
+1. **Workflow triggers** on the `v*` tag push. The `verify-and-build` job starts immediately.
+2. **Signature verification** runs (`git tag -v <tag>` against `.github/release-signing-key.pub`). If unsigned or signed by an unknown key, the workflow aborts here — no artifact is built.
+3. **Build** runs `python -m build`, producing `dist/<name>-<version>.whl` and `dist/<name>-<version>.tar.gz`.
+4. **Approval gate fires** on the `publish` job (the `pypi` GitHub Environment requires reviewer approval). You'll get a GitHub notification; visit the Actions UI and click "Approve" to proceed.
+5. **Publish** uploads the wheel + sdist to PyPI via Trusted Publisher (OIDC, no API token). PEP 740 attestations are generated and uploaded automatically by `pypa/gh-action-pypi-publish` when using Trusted Publisher.
+6. **GitHub Release** is created with the annotated tag's body as the release body and the built artifacts attached.
+
+If anything fails after approval, you'll see the failure in the Actions UI. The most common late-stage failure is a PyPI rejection (e.g., version already exists), which means you need to bump the version and re-tag.
+
+### Prerequisites (one-time setup)
+
+Local git must be configured to sign tags with the project's dedicated SSH release-signing key. If you already followed the project's `CONTRIBUTING.md` Setup B-iii section, you're done. Otherwise:
+
+```bash
+git config gpg.format ssh
+git config tag.gpgSign true
+git config user.signingkey <absolute path to your public key (.pub)>
+git config gpg.ssh.allowedSignersFile .git/allowed_signers
+```
+
+And a one-line `.git/allowed_signers` file containing:
+
+```
+<your-email> <pasted contents of the .pub file>
+```
+
+The dedicated private key is local-only — it does not live in the repo. The public half is at `.github/release-signing-key.pub` and pinned in the "Trusted public signing key" section below.
+
+---
+
+## For users: verifying a release
+
+### Path A: PyPI attestations (recommended for installable artifacts)
+
+The official PyPI-native verification path uses `pypi-attestations`, a FLOSS CLI maintained by PyPA.
+
+**Install:**
+
+```bash
+pip install pypi-attestations
+```
+
+**Verify** a wheel or sdist (replace `<version>` with the release you're checking):
+
+```bash
+# Against a local file
+pip download --no-deps pic-standard==<version>
+pypi-attestations verify pypi \
+    --repository https://github.com/madeinplutofabio/pic-standard \
+    pic_standard-<version>-py3-none-any.whl
+
+# Or against the PyPI URL directly (no local download)
+pypi-attestations verify pypi \
+    --repository https://github.com/madeinplutofabio/pic-standard \
+    https://files.pythonhosted.org/packages/.../pic_standard-<version>-py3-none-any.whl
+```
+
+**What the tool checks:**
+
+- Fetches the attestation from PyPI
+- Validates the Sigstore-issued certificate against the Trusted Publisher policy (workflow `release.yml` from `madeinplutofabio/pic-standard`)
+- Confirms the artifact bytes match the attestation's payload hash
+- Cross-references the Sigstore transparency log
+
+**Success output:** `OK!` (or equivalent verbose output indicating the attestation verified). **Failure output:** specific error indicating which check failed (signature mismatch, no attestation found, wrong publisher, etc.).
+
+**Alternative (PyPI web UI):** PyPI exposes attestation/provenance information on the distribution file details view (https://pypi.org/project/pic-standard/). The CLI verification path above is the canonical, copy-pasteable check.
+
+### Path B: Git tag signature
+
+For users working with the source tree (cloning, auditing, building from source).
+
+**One-time setup** — create a local allowed_signers file pinning the project's release-signing key:
+
+```bash
+# Make a directory for the policy file (choose any path you like).
+mkdir -p ~/.config/git
+
+# Write the trusted-signer entry. Format per Git's docs: one or more
+# principals followed by the SSH public key. The key value below is the
+# canonical public key for pic-standard releases (also pinned in
+# .github/release-signing-key.pub in the repository).
+cat > ~/.config/git/pic-allowed-signers <<'EOF'
+fabio@madeinpluto.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDhoOQt2X+irvPwMj1zRuCAIhdH0kV3nKFiQzHLx/luS PIC Standard release signing key (madeinplutofabio)
+EOF
+```
+
+**Verify a tag:**
+
+```bash
+git fetch origin --tags
+git -c gpg.format=ssh \
+    -c gpg.ssh.allowedSignersFile=~/.config/git/pic-allowed-signers \
+    tag -v v<version>
+```
+
+**Success output:** `Good "git" signature for fabio@madeinpluto.com with ED25519 key SHA256:blCcqBpKLCrJUtUYwOvxE3tmUa4F37/COJvy8F80hHg`
+
+**Failure output:** `error: no signature found` (tag is unsigned) or `Could not verify signature` (signed by a key not in your allowed_signers). Both should be treated as failed verification.
+
+**Persistent setup** (if you verify pic-standard tags often): add the config lines to your global git config instead of using `git -c` inline:
+
+```bash
+git config --global gpg.ssh.allowedSignersFile ~/.config/git/pic-allowed-signers
+git config --global gpg.format ssh   # WARNING: applies globally — see note
+```
+
+⚠️ Note: `gpg.format ssh` is repo-local in our project setup (per `CONTRIBUTING.md`), but if you set it globally it affects every repo that signs tags/commits. If you sign for another project using GPG, don't set this globally.
+
+**Alternative (GitHub web UI):** GitHub shows tag verification status in the **Releases → Tags** view (https://github.com/madeinplutofabio/pic-standard/tags). A "Verified" indicator on a tag reflects GitHub's server-side check against the maintainer's registered Signing Key, equivalent verification to running `git tag -v` locally.
+
+---
+
+## Trusted public signing key
+
+**Algorithm:** Ed25519
+**Format:** OpenSSH
+**Status:** Active
+
+### Public key (copy this entire line as one line)
+
+```
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDhoOQt2X+irvPwMj1zRuCAIhdH0kV3nKFiQzHLx/luS PIC Standard release signing key (madeinplutofabio)
+```
+
+### SHA256 fingerprint (for out-of-band verification)
+
+```
+SHA256:blCcqBpKLCrJUtUYwOvxE3tmUa4F37/COJvy8F80hHg
+```
+
+### Where else this key appears
+
+The same key value (with matching fingerprint) is published in three places. They MUST all agree:
+
+1. **This document** (the section above)
+2. **`.github/release-signing-key.pub`** in this repository — the file the release workflow reads to construct its runtime verification policy
+3. **`madeinplutofabio`'s GitHub Signing Keys list** at https://github.com/settings/keys — what GitHub uses to display the "Verified" badge on signed tags
+
+Out-of-band fingerprint verification: a user comparing the fingerprint from this file (read at a known git commit) against the fingerprint shown in their cloned tree provides defense-in-depth against in-transit tampering of the verification process itself.
+
+---
+
+## Troubleshooting
+
+### `pypi-attestations verify pypi` fails with "no attestations found"
+
+The artifact was uploaded **before** Trusted Publisher + PEP 740 attestations were wired up. Pre-`v<first signed version>` releases are **unsigned legacy artifacts** — they cannot be verified through this path. The first signed release with attestations is the first release whose tag triggered the `release.yml` workflow after PR-B merged.
+
+### `git tag -v` fails with "error: no signature found"
+
+The tag was created with `git tag -a` (annotated, unsigned) rather than `git tag -s` (annotated and signed). Pre-`v<first signed version>` tags are unsigned-legacy. Modern tags should always show a valid signature; if a recent tag is unsigned, either (a) the maintainer skipped signing (a process error — open an issue) or (b) the workflow's verify-signature step would have rejected it and you shouldn't see a corresponding GitHub Release in any case.
+
+### `git tag -v` fails with "Could not verify signature"
+
+The tag was signed by a key that's not in your `allowed_signers` file. Possible causes:
+
+- You're using an outdated `allowed_signers` (the project rotated keys — see "Key rotation" below)
+- The tag was signed by an unauthorized party (treat this as a security incident; open an issue)
+
+Re-populate your `allowed_signers` with the current canonical line from this document, then retry.
+
+### GitHub doesn't show the "Verified" badge but `git tag -v` locally succeeds
+
+This can happen if the maintainer's GitHub Signing Key registration was removed, expired, or is otherwise out of sync with the publicly-pinned key. The local `git tag -v` is the authoritative check; GitHub's UI badge is a convenience layer. If they disagree, the local check (against the pinned key) is the source of truth.
+
+### Workflow run fails at the "Verify tag signature" step
+
+This is the workflow correctly rejecting an unsigned or wrongly-signed tag. The maintainer needs to:
+
+1. Delete the unsigned/wrong-signed tag locally and remotely
+2. Re-tag with `git tag -s`
+3. Push the corrected tag
+
+If a maintainer's local git config doesn't auto-sign tags, the workflow catches it here instead of in a downstream consumer surfacing an unverifiable release.
+
+---
+
+## Key rotation
+
+If the dedicated SSH release-signing private key is compromised, lost, or otherwise needs replacement:
+
+1. **Generate a new Ed25519 key** following the procedure in `CONTRIBUTING.md` Setup B-ii (use a different filename, e.g., `pic_standard_release_signing_v2`).
+2. **Update `.github/release-signing-key.pub`** with the new public key contents.
+3. **Update this `RELEASING.md`** — replace the "Trusted public signing key" section with the new key + fingerprint. Add a "Previous keys" subsection (if it doesn't exist) and append the old key with its retirement date for historical reference.
+4. **Update `madeinplutofabio`'s GitHub Signing Keys list**: register the new key, then remove the old one.
+5. **Update local git config** (`user.signingkey` path) to point at the new public key (`.pub`).
+6. **Land the changes** as a single PR titled e.g., `chore: rotate release signing key (v2)`.
+7. **Document the rotation event** in the PR description: when, why, and how downstream users should update their `allowed_signers`.
+
+After rotation, the next tag signed with the new key will not be verifiable by users who haven't updated their `allowed_signers` file. The rotation event must be communicated (release notes, security advisory if applicable).
+
+Old releases signed by the retired key remain verifiable if users retain the old key's entry in their `allowed_signers` policy. This document's "Previous keys" subsection serves as the canonical archive of retired keys.
+
+---
+
+## Notes on the OpenSSF Best Practices framing
+
+The OpenSSF Best Practices `signed_releases` criterion was originally written assuming a **classic long-lived artifact-signing public-key model** ("documented process explaining to users how they can obtain the public signing keys and verify the signature(s)"). pic-standard's verification model is **two-layered and combines both modern and classic patterns**:
+
+- **Layer 1 (PyPI artifacts):** modern Sigstore-issued ephemeral certificates per workflow run, anchored by GitHub Actions OIDC + Sigstore's transparency log. There is no long-lived artifact-signing public key for this layer — trust roots back to GitHub identity. This is the path PyPI's own consumer documentation publishes for verifying PEP 740 attestations.
+
+- **Layer 2 (git tags):** classic long-lived public-key model. The Ed25519 signing key is published in-repo (`.github/release-signing-key.pub`), pinned in this document, and registered on GitHub. Verification uses the standard `git tag -v` + `allowed_signers` flow.
+
+Both layers run for every release. The criterion's spirit — cryptographic verifiability + documented process + signing key not exclusively on the distribution site — is fully satisfied across both layers. A reviewer focused on "where is the public key?" can point at the Layer 2 SSH key. A reviewer focused on "modern attestation flow?" can point at the Layer 1 PyPI-attestations path.
+
+If a reviewer asks for the project's long-lived public signing key, use the Layer 2 SSH tag-signing key (pinned above). Artifact verification itself is documented separately through the Layer 1 PyPI-attestations path — that path is identity-based and does not rely on a long-lived artifact-signing key.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,3 +65,14 @@ Reporters are credited in the published advisory unless they explicitly request 
 ## Cryptographic signing of communications
 
 PGP-signed reports and acknowledgments are not currently supported — no maintainer signing key has been published. This is a known gap; a maintainer key will be published in this document when one exists. In the interim, the private channel of GitHub Security Advisories is the only supported reporting path.
+
+## Verifying releases
+
+PIC Standard releases produced via the project's release pipeline are cryptographically signed in two complementary ways:
+
+- **PyPI distribution artifacts** (wheel + sdist): signed via [PEP 740 attestations](https://peps.python.org/pep-0740/) (Sigstore-backed, tied to a GitHub Actions Trusted Publisher workflow identity — `madeinplutofabio/pic-standard` running `release.yml` under the `pypi` environment).
+- **Git tags**: signed with the project's dedicated Ed25519 release-signing key (the public half is pinned in [`.github/release-signing-key.pub`](.github/release-signing-key.pub)).
+
+For verification commands, the trusted public signing key + SHA256 fingerprint, troubleshooting, and key rotation procedure, see **[`RELEASING.md`](RELEASING.md)**.
+
+Releases predating the signing infrastructure are unsigned legacy artifacts. The cutover version is documented in `RELEASING.md`.


### PR DESCRIPTION
## Summary

OpenSSF Best Practices **Passing-tier release-signing infrastructure**. Two criteria are addressed:

| Criterion | Tier | Status before | Status on merge | Status after first signed release |
|---|---|---|---|---|
| `signed_releases` | Passing (MUST) | UNMET | Infrastructure complete; first signed release **pending** | **MET** |
| `version_tags_signed` | Passing (SUGGESTED) | UNMET | Infrastructure complete; first signed tag **pending** | **MET** |

**Path α is locked:** v0.8.1.1 shakedown release will be cut immediately after this PR merges, exercising the full signing pipeline end-to-end and flipping both criteria to MET before any v0.8.2 substantive work begins.

## Release pipeline shape

**`.github/workflows/release.yml`** — 2-job workflow, triggered by `v*` tag pushes:

1. **`verify-and-build`** (runs immediately, NO approval gate)
   - Verifies the tag's SSH signature against the trusted public key (`.github/release-signing-key.pub`). Workflow aborts here if unsigned or signed by an unknown key — **no artifact gets built**.
   - Builds wheel + sdist via `python -m build`.
   - Uploads artifacts for the publish job.

2. **`publish`** (gated by the `pypi` GitHub Environment — requires maintainer approval)
   - Publishes to PyPI via `pypa/gh-action-pypi-publish@release/v1` (Trusted Publisher; no API token; PEP 740 attestations auto-generated).
   - Creates GitHub Release via `softprops/action-gh-release@v2` with the annotated tag's subject + body as release notes (signature block excluded — uses `%(subject)` + `%(contents:body)` from `git tag -l --format=...`, NOT `%(contents)` which would leak the OpenSSH signature block into release notes).

**Pinning rationale:**
- `pypa/gh-action-pypi-publish@release/v1` — PyPA-recommended floating-major branch; PyPA maintains security patches in-place.
- `softprops/action-gh-release@v2` — widely-used community action; v2 stable.
- `actions/checkout@v4`, `actions/setup-python@v5`, `actions/upload-artifact@v4`, `actions/download-artifact@v4` — first-party majors, conventional.
- Dependabot's existing `github-actions` ecosystem block (`/.github/dependabot.yml`) tracks tag-pinned actions for weekly minor/patch updates, ignoring major bumps (manual review required).

## Trust anchor

**`.github/release-signing-key.pub`** — the pinned Ed25519 public signing key. The workflow reads this file at runtime to construct its `allowed_signers` verification policy. The same key value is published in three places, all required to agree:

1. `.github/release-signing-key.pub` (this PR)
2. `RELEASING.md`'s "Trusted public signing key" section (this PR)
3. `madeinplutofabio`'s GitHub Signing Keys list (registered out-of-band; visible at https://github.com/settings/keys)

**Fingerprint:** `SHA256:blCcqBpKLCrJUtUYwOvxE3tmUa4F37/COJvy8F80hHg`

**Byte-verified locally** via an end-to-end signed-tag round-trip: a tag signed with the local private key was verified against an `allowed_signers` constructed from the committed `.github/release-signing-key.pub` — same fingerprint, "Good signature" output. The workflow's runtime verification step will succeed identically on a fresh runner.

## Maintainer setup (already complete; documented for future maintainers)

Per the locked plan, all maintainer-side infrastructure was set up before this PR was opened:

- ✅ **PyPI Trusted Publisher** registered: project `pic-standard`, owner `madeinplutofabio`, workflow `release.yml`, environment `pypi`.
- ✅ **GitHub Environment `pypi`** created with:
  - Required reviewer (maintainer approval gate before deploy)
  - Deployment branch/tag rule: `v*` only (defense-in-depth against accidental non-tag runs)
- ✅ **Dedicated Ed25519 SSH release-signing key** generated locally (passphrase-protected, separate from any auth key).
- ✅ **Public half registered on GitHub** as a Signing Key (NOT an Authentication Key — distinct category).
- ✅ **Local git config** in the maintainer's clone:
  - `gpg.format = ssh`
  - `tag.gpgSign = true`
  - `gpg.ssh.allowedSignersFile = .git/allowed_signers`
  - `user.signingkey = <path to private key>`
- ✅ **End-to-end signing test passed**: `git tag -s ...` → `git tag -v ...` → `Good "git" signature for fabio@madeinpluto.com with ED25519 key SHA256:blCcqBpKLCrJUtUYwOvxE3tmUa4F37/COJvy8F80hHg`

All of this is documented in `RELEASING.md` (Prerequisites section) so future maintainers can replicate the setup before cutting their first release.

## Documentation changes

- **`RELEASING.md`** (NEW): comprehensive maintainer + user reference. Sections:
  - Trust model overview (two-layer: PyPI attestations + git tag signatures)
  - For maintainers: cutting a release, what happens after `git push`, prerequisites
  - For users: verifying a release via `pypi-attestations` (Layer 1) and `git tag -v` (Layer 2)
  - Trusted public signing key (pinned value + fingerprint + cross-place agreement table)
  - Troubleshooting (common verification failure modes)
  - Key rotation procedure
  - Notes on OpenSSF Best Practices framing
- **`SECURITY.md`**: "Verifying releases" section appended, cross-linking `RELEASING.md` and the in-repo pinned public key.
- **`CONTRIBUTING.md`**: "Release Process" section added (between Governance Model and Code of Conduct) documenting the signed-tag requirement and pointing maintainers at `RELEASING.md`.
- **`README.md`**: "Signed releases | Sigstore + SSH" badge added to the badge row, linking to `RELEASING.md`.

## Notes on the OpenSSF framing (for the questionnaire)

The `signed_releases` criterion text was originally written assuming a **classic long-lived artifact-signing public-key model**. pic-standard's model is **two-layered**:

- **Layer 1 (PyPI artifacts):** modern Sigstore-issued ephemeral certificates per workflow run, anchored by GitHub Actions OIDC + Sigstore's transparency log. No long-lived artifact-signing public key for this layer — trust roots back to GitHub identity.
- **Layer 2 (git tags):** classic long-lived public-key model. The Ed25519 signing key is published in-repo, pinned in `RELEASING.md`, and registered on GitHub.

Both layers run for every release. The criterion's spirit is fully satisfied across both. If a reviewer asks for the project's long-lived public signing key, point at the Layer 2 SSH tag-signing key. Artifact verification is documented separately through the Layer 1 PyPI-attestations path.

This framing is also explicit in `RELEASING.md`'s "Notes on the OpenSSF Best Practices framing" section — ready-to-quote for the questionnaire response.

## Verification before merge

- ✅ Workflow file is syntactically valid YAML
- ✅ Local signing chain works end-to-end (`git tag -s` → `git tag -v` → "Good signature")
- ✅ `.github/release-signing-key.pub` is byte-identical to the local source `.pub` (verified via signed-tag round-trip)
- ✅ PR-A's CI gates (ruff, coverage, vitest, tsc) remain green on this branch — purely additive infrastructure, no code/test files touched

## Verification AFTER merge (gating the first signed release)

When v0.8.1.1 is tagged and pushed (Path α):

- [ ] Workflow `release.yml` runs to completion (verify → build → maintainer approves → publish → GitHub Release)
- [ ] PyPI artifact attestation visible at https://pypi.org/project/pic-standard/<version>/
- [ ] `pypi-attestations verify pypi --repository https://github.com/madeinplutofabio/pic-standard <wheel-url>` passes
- [ ] `git fetch origin --tags && git tag -v v0.8.1.1` prints "Good signature" against the pinned key
- [ ] GitHub Releases → Tags view shows "Verified" indicator on v0.8.1.1
- [ ] OpenSSF Best Practices questionnaire flipped: `signed_releases` → MET, `version_tags_signed` → MET

## Follow-up trail

Tracked from PR-A's open backlog (not affected by this PR):

| # | Task | Status |
|---|---|---|
| F1 | Silence `PICTrustFutureWarning` in pytest output | Chip queued |
| F2 | Bump vitest to v4 in pic-guard | Chip queued |
| F3 | Triage OpenClaw peer-tree audit findings; raise peer floor when upstream patches land | Chip queued |
| F4 | Adopt canonical LF line endings repo-wide | Chip queued |
| F5 *(conditional)* | Add TS coverage if OpenSSF reviewer challenges Python-only scope | Not spawned |
| F6 | Switch `ci.yml` to `python -m coverage run` form for invocation robustness | Tracked |
| F7 | Clarify Python-only scope wording in `CONTRIBUTING.md` coverage bullet | Tracked |

## Test plan

- [ ] CI passes on this branch (PR-A's gates: ruff, coverage, vitest, tsc — purely additive infrastructure, no regression expected)
- [ ] After merge: cut v0.8.1.1 via `git tag -s v0.8.1.1 -m "..."` and `git push origin v0.8.1.1`
- [ ] Workflow runs end-to-end; both verification layers succeed against the published release
- [ ] OpenSSF questionnaire updated to flip criteria 3 + 4 to MET
