### PR TITLE
release: v0.8.1.1 (shakedown release of signing infrastructure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 This project follows Semantic Versioning:
 https://semver.org/
 
+## [0.8.1.1] - 2026-05-11
+
+Shakedown release through the new signing infrastructure. **No protocol changes vs v0.8.1.**
+
+This release exists to exercise the release-signing pipeline (PR #77) end-to-end and produce the first PyPI artifact bearing PEP 740 attestations + the first git tag signed with the project's dedicated Ed25519 release-signing key.
+
+### Notes
+- **No code or protocol changes vs v0.8.1.** Hygiene/infrastructure-only since v0.8.1: code-style enforcement (Ruff + ESLint/Prettier) and 80% Python statement-coverage gate (PR #73); release-signing pipeline (PR #77).
+- **First signed release.** Pre-`v0.8.1.1` releases are unsigned legacy artifacts. See [`RELEASING.md`](RELEASING.md) for verification commands and the trusted public signing key fingerprint.
+
+---
+
 ## [0.8.1] - 2026-05-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pic-standard"
-version = "0.8.1"
+version = "0.8.1.1"
 description = "PIC Standard: Provenance & Intent Contracts for agentic side-effect governance"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Version bump for the **v0.8.1.1 shakedown release** — the first release through the new signing infrastructure landed by PR #77 (release pipeline) and PR #73 (style + coverage gates).

Two file changes:
- `pyproject.toml`: version `0.8.1` → `0.8.1.1`
- `CHANGELOG.md`: new entry documenting the shakedown nature of this release

## Why this release

PR #77 introduced the release-signing pipeline but the infrastructure remains "complete but pending first run" until a real tag exercises the workflow end-to-end. v0.8.1.1 is that exercise: a minimal post-release whose only purpose is to demonstrate the PEP 740 attestation flow and signed-tag verification path are working in production.

**No protocol changes vs v0.8.1.** Includes the hygiene/infrastructure work landed since v0.8.1:
- Code-style enforcement (Ruff + ESLint/Prettier) and 80% Python coverage gate (PR #73)
- Release-signing pipeline (PR #77)

The npm-side `pic-guard` package (`integrations/openclaw/package.json`) is **intentionally left at `0.8.1`** — this is a PyPI-only shakedown; no npm release is cut from this tag. The two packages are versioned independently.

## What happens after merge

1. Merge this PR (squash; standard pattern)
2. Pull main locally
3. `git tag -s v0.8.1.1 -m "..."` — signed tag with maintainer-authored release notes
4. `git push origin v0.8.1.1` — triggers `.github/workflows/release.yml`
5. Workflow verifies tag signature against `.github/release-signing-key.pub`, builds wheel + sdist
6. **Approval gate fires** — maintainer clicks "Approve" in GitHub Actions UI (the `pypi` environment requires explicit reviewer approval)
7. Workflow publishes to PyPI via Trusted Publisher + creates GitHub Release with the annotated tag body as release notes
8. Verify end-to-end (commands in `RELEASING.md`)
9. Update OpenSSF Best Practices questionnaire — flip `signed_releases` and `version_tags_signed` to **MET**

## Verification

- CI must pass on this branch (PR-A's gates remain green; PR-B's infrastructure files are untouched on this branch — version bump only)
- After merge: the `release.yml` workflow's end-to-end run is the load-bearing verification

## Test plan

- [ ] CI green on this branch (5 status checks)
- [ ] After merge: tag `v0.8.1.1`, push, observe workflow completion
- [ ] `pypi-attestations verify pypi --repository https://github.com/madeinplutofabio/pic-standard <wheel-url>` succeeds
- [ ] `git fetch origin --tags && git tag -v v0.8.1.1` prints "Good signature" with fingerprint `SHA256:blCcqBpKLCrJUtUYwOvxE3tmUa4F37/COJvy8F80hHg`
- [ ] GitHub Releases → Tags view shows "Verified" indicator on v0.8.1.1
- [ ] OpenSSF Best Practices questionnaire flipped: `signed_releases` → MET, `version_tags_signed` → MET
