### PR TITLE
fix(release.yml): refresh annotated tag object after actions/checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,22 @@ jobs:
           # tag's signature payload.
           fetch-depth: 0
 
+      - name: Refresh annotated tag object
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          # actions/checkout with a tag ref creates a LIGHTWEIGHT tag
+          # locally (pointer-to-commit); the annotated tag OBJECT with
+          # the signature payload and the tag body is not preserved,
+          # even with fetch-depth: 0. Re-fetch with --force to overwrite
+          # the lightweight ref with the actual annotated tag object.
+          # Without this, `git tag -v` fails with "cannot verify a
+          # non-tag object of type commit" and `%(subject)/%(contents:body)`
+          # return empty.
+          git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --force
+          # Sanity-check: confirm the local ref is now an annotated tag.
+          git cat-file -t "${TAG}"   # prints "tag" (not "commit")
+
       - name: Verify tag signature against trusted public key
         env:
           TAG: ${{ github.ref_name }}
@@ -119,6 +135,16 @@ jobs:
         with:
           # Needed for the annotated-tag-body extraction step below.
           fetch-depth: 0
+
+      - name: Refresh annotated tag object
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          # Same workaround as the verify-and-build job — actions/checkout
+          # creates a lightweight tag locally; refresh from origin so the
+          # annotated tag body is available to `git tag -l --format=...`.
+          git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --force
+          git cat-file -t "${TAG}"   # prints "tag" (not "commit")
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

Fixes the `release.yml` workflow which failed at the tag-verification step during the v0.8.1.1 shakedown release attempt.

## Root cause

`actions/checkout@v4`, when checking out a tag ref, creates a **lightweight** tag locally (a pointer-to-commit), not an annotated tag object. The annotated tag's signature payload and body content are never preserved, even with `fetch-depth: 0`.

This caused two downstream failures in the original workflow:

1. **`verify-and-build` job:** `git tag -v "$TAG"` exited with `error: v0.8.1.1: cannot verify a non-tag object of type commit.` because the local ref is a commit, not a tag.
2. **`publish` job (latent):** `git tag -l --format='%(subject)%(contents:body)'` would have returned **empty** for lightweight tags — the release notes body would have been empty even if the workflow had reached that step.

## Fix

Add a `Refresh annotated tag object` step after `Checkout` in both jobs. The step:

- Re-fetches the specific tag with `--force`, overwriting the lightweight ref with the actual annotated tag object from origin
- Sanity-checks the result with `git cat-file -t "$TAG"` which prints `tag` (not `commit`) when successful

The fetch is surgical (only the one tag being verified, not all tags) and idempotent.

## Test plan

- [ ] CI passes on this branch (PR-A's gates: ruff, coverage, vitest, tsc — purely a workflow file change, no code touched)
- [ ] After merge: delete and re-create the `v0.8.1.1` tag (locally and remotely), push, and verify the workflow run completes through both jobs

## Notes

- This is the first workflow that exercises the signing pipeline; the lightweight-tag gotcha is a well-known `actions/checkout` behavior but only surfaces when downstream steps need annotated-tag metadata (most workflows don't).
- The existing `v0.8.1.1` tag is unaffected on the remote (still signed correctly); we'll re-tag against the fixed workflow after this PR merges.
