### PR TITLE
chore: bump GitHub Actions to Node-24-native versions (F8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -77,10 +77,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Full history + tags so `git tag -v` can read the annotated
           # tag's signature payload.
@@ -87,7 +87,7 @@ jobs:
           git tag -v "$TAG"
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -100,7 +100,7 @@ jobs:
         run: python -m build
 
       - name: Upload build artifacts for publish job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/
@@ -125,13 +125,13 @@ jobs:
       # generation. The PyPA action exchanges this token with PyPI for an
       # ephemeral upload credential.
       id-token: write
-      # Required for softprops/action-gh-release@v2 to create the Release
+      # Required for softprops/action-gh-release to create the Release
       # and attach assets.
       contents: write
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Needed for the annotated-tag-body extraction step below.
           fetch-depth: 0
@@ -147,7 +147,7 @@ jobs:
           git cat-file -t "${TAG}"   # prints "tag" (not "commit")
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/
@@ -175,7 +175,7 @@ jobs:
           echo "body-path=release-body.md" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           # Use the annotated tag's subject + body (no signature block).
           body_path: ${{ steps.tag-body.outputs.body-path }}


### PR DESCRIPTION
## Summary

Bumps all GitHub Actions in the three workflow files to their Node-24-native major versions, ahead of the **2026-06-02 forced-default flip** announced in GitHub Actions' Node 20 deprecation notice. Forced removal is 2026-09-16; this PR resolves the deprecation warning we've been seeing on every workflow run since v0.8.1.1.

**No protocol changes, no behavior changes, no version bump.** Pure dev-infrastructure transition.

Second of the 3-PR post-Silver cleanup cluster:
- **PR-C (merged):** F1 + F6 + F7 — small hygiene tweaks (#83)
- **PR-D (this PR):** F8 — Node-24 action transition
- **PR-E (next):** F2 — vitest v4 bump

## Changes

### Version bumps (5 distinct actions, 6 line changes — `checkout` appears in two jobs in `release.yml`)

| Action | From | To | Used in |
|---|---|---|---|
| `actions/checkout` | `@v4` | `@v5` | `ci.yml` (×2 jobs), `conformance.yml`, `release.yml` (×2 jobs) |
| `actions/setup-python` | `@v5` | `@v6` | `ci.yml`, `conformance.yml`, `release.yml` |
| `actions/setup-node` | `@v4` | `@v5` | `ci.yml` (test-openclaw job) |
| `actions/upload-artifact` | `@v4` | `@v6` | `release.yml` |
| `actions/download-artifact` | `@v4` | `@v7` | `release.yml` |
| `softprops/action-gh-release` | `@v2` | `@v3` | `release.yml` |

All target versions have explicitly moved their runtime to Node 24 per upstream release notes.

### `actions/setup-node` — deliberately v5, NOT v6

`setup-node@v5` already moved its runtime to Node 24 (requires GitHub Actions runner ≥ v2.327.1). `setup-node@v6` exists and goes further, but adds breaking-change surface around automatic caching that we don't need. Goal here is Node-24 compatibility, not "latest major everywhere."

### `pypa/gh-action-pypi-publish` left untouched

Pinned to `@release/v1` (a floating-major branch ref, PyPA-recommended). PyPA maintains this branch with Node-24 compatibility upstream; no action needed on our side.

### Comment cleanup

One nearby comment in `release.yml` was version-stamped to `@v2` (which would have gone stale immediately after the `softprops/action-gh-release` bump):

```diff
-      # Required for softprops/action-gh-release@v2 to create the Release
+      # Required for softprops/action-gh-release to create the Release
```

Stripped the `@v2` so the comment is version-agnostic and stays accurate across future bumps.

## Verification

### Pre-merge (this PR's CI)

- ✅ `ci.yml` runs on new action versions — expect all 4 matrix cells (3.10/3.11/3.12 pinned + 3.12 latest) to pass
- ✅ `conformance.yml` runs on new action versions — expect conformance vector suite to pass
- ✅ Workflow logs should NO LONGER show the Node 20 deprecation warning that's been appearing since v0.8.1.1

### Post-merge (release.yml — tag-triggered only)

`release.yml` cannot be exercised by PR-time CI (its trigger is `push: tags: v*`, not push/PR). First real verification is the next release tag. Risk areas to watch on that release:

- **`actions/upload-artifact@v6` / `download-artifact@v7`** — artifact format v4 was the "no concurrent uploads to same name" era; v5+ removed some legacy paths. Our usage (single-artifact upload in verify-and-build, single-artifact download in publish) stays within the supported pattern.
- **`softprops/action-gh-release@v3`** — explicit Node 24 runtime move. Spot-checked: the inputs we use (`body_path`, `files`, `prerelease`, `make_latest`) are unchanged in v3; v3's documented major changes are about the runtime, not input rename.

### Fallback (if any action bump reveals breakage)

For each affected action, revert to v-prev in a follow-up PR and add `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at the workflow level. Forces Node 24 on the v4/v5 action versions as a temporary bridge while we investigate. Reversible quickly.

## Out of scope

- **`pypa/gh-action-pypi-publish` version bump** — not needed; floating branch ref is the PyPA-recommended pin form.
- **Bumping to `actions/setup-node@v6`** — deliberately stopping at v5 (Node 24 sufficient; v6 adds auto-caching breaking changes we don't want).
- **F2 vitest v4 bump** — separate PR (PR-E).
- **F4 LF line-ending normalization** — deferred entirely.

## Test plan

- [ ] CI passes on this branch (`ci.yml` + `conformance.yml` — these are tested by PR-time CI)
- [ ] Workflow logs no longer show "Node.js 20 actions are deprecated" warning
- [ ] After merge: monitor next release run (tag-triggered) for any artifact / GitHub-Release-creation surprises; `pypi-attestations verify pypi ...` and `git tag -v` should continue to succeed end-to-end

No version bump, no CHANGELOG entry, no release. Mention will land in the v0.8.2 CHANGELOG entry under "Notes."
