### PR TITLE
chore: bump vitest to v4 in pic-guard (F2)

### DIFF
--- a/integrations/openclaw/package-lock.json
+++ b/integrations/openclaw/package-lock.json
@@ -15,7 +15,7 @@
                 "prettier": "^3.0.0",
                 "typescript": "^5.9.3",
                 "typescript-eslint": "^8.0.0",
-                "vitest": "^1.6.1"
+                "vitest": "^4.0.0"
             },
             "engines": {
                 "node": ">=18.0.0"
@@ -1092,428 +1092,34 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
-            "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
-                "@emnapi/wasi-threads": "1.2.0",
+                "@emnapi/wasi-threads": "1.2.1",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
-            "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-            "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-            "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "aix"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/android-arm": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-            "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/android-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-            "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/android-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-            "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-            "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/darwin-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-            "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-            "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-            "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-arm": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-            "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-            "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-ia32": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-            "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-loong64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-            "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-            "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-            "cpu": [
-                "mips64el"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-            "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-            "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-s390x": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-            "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-            "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-            "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-            "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/sunos-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-            "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/win32-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-            "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/win32-ia32": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-            "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/win32-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-            "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -2519,26 +2125,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@jest/schemas": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-            "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.27.8"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/schemas/node_modules/@sinclair/typebox": {
-            "version": "0.27.10",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-            "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -3320,20 +2906,21 @@
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-            "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1",
                 "@tybys/wasm-util": "^0.10.1"
             },
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
             }
         },
         "node_modules/@node-llama-cpp/linux-arm64": {
@@ -3928,6 +3515,16 @@
                 "node": ">= 20"
             }
         },
+        "node_modules/@oxc-project/types": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
+            "integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
         "node_modules/@pinojs/redact": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
@@ -4177,24 +3774,10 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-            "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ]
-        },
-        "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-            "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
+            "integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
             "cpu": [
                 "arm64"
             ],
@@ -4203,12 +3786,15 @@
             "optional": true,
             "os": [
                 "android"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-            "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
+            "integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
             "cpu": [
                 "arm64"
             ],
@@ -4217,12 +3803,15 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-            "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
+            "integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
             "cpu": [
                 "x64"
             ],
@@ -4231,26 +3820,15 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
-        },
-        "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-            "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
-            "cpu": [
-                "arm64"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-            "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
+            "integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
             "cpu": [
                 "x64"
             ],
@@ -4259,12 +3837,15 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-            "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
+            "integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
             "cpu": [
                 "arm"
             ],
@@ -4273,26 +3854,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-            "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
-            "cpu": [
-                "arm"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-            "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
+            "integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
             "cpu": [
                 "arm64"
             ],
@@ -4301,12 +3871,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-            "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
+            "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
             "cpu": [
                 "arm64"
             ],
@@ -4315,40 +3888,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-            "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
-            "cpu": [
-                "loong64"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-            "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-            "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
+            "integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
             "cpu": [
                 "ppc64"
             ],
@@ -4357,54 +3905,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-            "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
-            "cpu": [
-                "ppc64"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-            "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-            "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-            "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
+            "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
             "cpu": [
                 "s390x"
             ],
@@ -4413,12 +3922,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-            "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
+            "integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
             "cpu": [
                 "x64"
             ],
@@ -4427,12 +3939,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-            "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
+            "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
             "cpu": [
                 "x64"
             ],
@@ -4441,26 +3956,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-            "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
-            "cpu": [
-                "x64"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-            "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
+            "integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
             "cpu": [
                 "arm64"
             ],
@@ -4469,12 +3973,34 @@
             "optional": true,
             "os": [
                 "openharmony"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-            "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
+            "integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.10.0",
+                "@emnapi/runtime": "1.10.0",
+                "@napi-rs/wasm-runtime": "^1.1.4"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
+            "integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
             "cpu": [
                 "arm64"
             ],
@@ -4483,26 +4009,15 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
-        },
-        "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-            "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
-            "cpu": [
-                "ia32"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-            "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
+            "integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
             "cpu": [
                 "x64"
             ],
@@ -4511,21 +4026,17 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
-        },
-        "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-            "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
-            "cpu": [
-                "x64"
             ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
+            "integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
             "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
+            "license": "MIT"
         },
         "node_modules/@silvia-odwyer/photon-node": {
             "version": "0.3.4",
@@ -5617,6 +5128,13 @@
                 "node": ">= 10"
             }
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@tinyhttp/content-disposition": {
             "version": "2.2.4",
             "resolved": "https://registry.npmjs.org/@tinyhttp/content-disposition/-/content-disposition-2.2.4.tgz",
@@ -5669,7 +5187,6 @@
             "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -5703,6 +5220,17 @@
                 "bun-types": "1.3.9"
             }
         },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
         "node_modules/@types/connect": {
             "version": "3.4.38",
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -5712,6 +5240,13 @@
             "dependencies": {
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.8",
@@ -6097,74 +5632,113 @@
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
-            "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+            "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "1.6.1",
-                "@vitest/utils": "1.6.1",
-                "chai": "^4.3.10"
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.6",
+                "@vitest/utils": "4.1.6",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+            "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.6",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+            "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
-            "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+            "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "1.6.1",
-                "p-limit": "^5.0.0",
-                "pathe": "^1.1.1"
+                "@vitest/utils": "4.1.6",
+                "pathe": "^2.0.3"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
-            "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+            "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "magic-string": "^0.30.5",
-                "pathe": "^1.1.1",
-                "pretty-format": "^29.7.0"
+                "@vitest/pretty-format": "4.1.6",
+                "@vitest/utils": "4.1.6",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
-            "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+            "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "tinyspy": "^2.2.0"
-            },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
-            "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+            "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "diff-sequences": "^29.6.3",
-                "estree-walker": "^3.0.3",
-                "loupe": "^2.3.7",
-                "pretty-format": "^29.7.0"
+                "@vitest/pretty-format": "4.1.6",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
@@ -6290,19 +5864,6 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
-        "node_modules/acorn-walk": {
-            "version": "8.3.5",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
-            "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.11.0"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/agent-base": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-8.0.0.tgz",
@@ -6401,13 +5962,13 @@
             "license": "Python-2.0"
         },
         "node_modules/assertion-error": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "*"
+                "node": ">=12"
             }
         },
         "node_modules/ast-types": {
@@ -6632,16 +6193,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/cac": {
-            "version": "6.7.14",
-            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/cacheable": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.3.tgz",
@@ -6698,22 +6249,13 @@
             }
         },
         "node_modules/chai": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
-            "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "assertion-error": "^1.1.0",
-                "check-error": "^1.0.3",
-                "deep-eql": "^4.1.3",
-                "get-func-name": "^2.0.2",
-                "loupe": "^2.3.6",
-                "pathval": "^1.1.1",
-                "type-detect": "^4.1.0"
-            },
             "engines": {
-                "node": ">=4"
+                "node": ">=18"
             }
         },
         "node_modules/chalk": {
@@ -6727,19 +6269,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/check-error": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-            "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "get-func-name": "^2.0.2"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/chmodrp": {
@@ -7099,13 +6628,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/confbox": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-            "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/content-disposition": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
@@ -7129,6 +6651,13 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/cookie": {
             "version": "0.7.2",
@@ -7283,19 +6812,6 @@
                 }
             }
         },
-        "node_modules/deep-eql": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
-            "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "type-detect": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/deep-extend": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -7353,7 +6869,6 @@
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
             "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -7366,16 +6881,6 @@
             "peer": true,
             "engines": {
                 "node": ">=0.3.1"
-            }
-        },
-        "node_modules/diff-sequences": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-            "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/discord-api-types": {
@@ -7569,6 +7074,13 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-module-lexer": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -7596,45 +7108,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/esbuild": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-            "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "esbuild": "bin/esbuild"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.21.5",
-                "@esbuild/android-arm": "0.21.5",
-                "@esbuild/android-arm64": "0.21.5",
-                "@esbuild/android-x64": "0.21.5",
-                "@esbuild/darwin-arm64": "0.21.5",
-                "@esbuild/darwin-x64": "0.21.5",
-                "@esbuild/freebsd-arm64": "0.21.5",
-                "@esbuild/freebsd-x64": "0.21.5",
-                "@esbuild/linux-arm": "0.21.5",
-                "@esbuild/linux-arm64": "0.21.5",
-                "@esbuild/linux-ia32": "0.21.5",
-                "@esbuild/linux-loong64": "0.21.5",
-                "@esbuild/linux-mips64el": "0.21.5",
-                "@esbuild/linux-ppc64": "0.21.5",
-                "@esbuild/linux-riscv64": "0.21.5",
-                "@esbuild/linux-s390x": "0.21.5",
-                "@esbuild/linux-x64": "0.21.5",
-                "@esbuild/netbsd-x64": "0.21.5",
-                "@esbuild/openbsd-x64": "0.21.5",
-                "@esbuild/sunos-x64": "0.21.5",
-                "@esbuild/win32-arm64": "0.21.5",
-                "@esbuild/win32-ia32": "0.21.5",
-                "@esbuild/win32-x64": "0.21.5"
             }
         },
         "node_modules/escalade": {
@@ -7990,83 +7463,14 @@
             "license": "MIT",
             "peer": true
         },
-        "node_modules/execa": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+        "node_modules/expect-type": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^8.0.1",
-                "human-signals": "^5.0.0",
-                "is-stream": "^3.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^5.1.0",
-                "onetime": "^6.0.0",
-                "signal-exit": "^4.1.0",
-                "strip-final-newline": "^3.0.0"
-            },
+            "license": "Apache-2.0",
             "engines": {
-                "node": ">=16.17"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/execa/node_modules/get-stream": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/execa/node_modules/is-stream": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/execa/node_modules/onetime": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-fn": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/execa/node_modules/signal-exit": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "node": ">=12.0.0"
             }
         },
         "node_modules/express": {
@@ -8656,16 +8060,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/get-func-name": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-            "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/get-intrinsic": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -9078,16 +8472,6 @@
                 "node": ">= 14"
             }
         },
-        "node_modules/human-signals": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=16.17.0"
-            }
-        },
         "node_modules/iconv-lite": {
             "version": "0.7.2",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -9432,13 +8816,6 @@
                 "jiti": "lib/jiti-cli.mjs"
             }
         },
-        "node_modules/js-tokens": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-            "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/js-yaml": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -9694,6 +9071,267 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/linkedom": {
             "version": "0.18.12",
             "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.12.tgz",
@@ -9727,23 +9365,6 @@
             "peer": true,
             "dependencies": {
                 "uc.micro": "^2.0.0"
-            }
-        },
-        "node_modules/local-pkg": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
-            "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mlly": "^1.7.3",
-                "pkg-types": "^1.2.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/locate-path": {
@@ -9862,16 +9483,6 @@
             "license": "Apache-2.0",
             "peer": true
         },
-        "node_modules/loupe": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-            "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "get-func-name": "^2.0.1"
-            }
-        },
         "node_modules/lowdb": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-7.0.1.tgz",
@@ -9979,13 +9590,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/merge-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/mime-db": {
             "version": "1.54.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -10011,19 +9615,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/mimic-fn": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/mimic-function": {
@@ -10086,26 +9677,6 @@
             "engines": {
                 "node": ">= 18"
             }
-        },
-        "node_modules/mlly": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.1.tgz",
-            "integrity": "sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.16.0",
-                "pathe": "^2.0.3",
-                "pkg-types": "^1.3.1",
-                "ufo": "^1.6.3"
-            }
-        },
-        "node_modules/mlly/node_modules/pathe": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/ms": {
             "version": "2.1.3",
@@ -10380,35 +9951,6 @@
             "optional": true,
             "peer": true
         },
-        "node_modules/npm-run-path": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^4.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/npm-run-path/node_modules/path-key": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/nth-check": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -10444,6 +9986,17 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/obug": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+            "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT"
         },
         "node_modules/octokit": {
             "version": "5.0.5",
@@ -10701,22 +10254,6 @@
             "peer": true,
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/p-limit": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
-            "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "yocto-queue": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/p-locate": {
@@ -11018,21 +10555,11 @@
             }
         },
         "node_modules/pathe": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/pathval": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-            "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "*"
-            }
         },
         "node_modules/pdfjs-dist": {
             "version": "5.5.207",
@@ -11115,25 +10642,6 @@
             "license": "MIT",
             "peer": true
         },
-        "node_modules/pkg-types": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-            "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "confbox": "^0.1.8",
-                "mlly": "^1.7.4",
-                "pathe": "^2.0.1"
-            }
-        },
-        "node_modules/pkg-types/node_modules/pathe": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/playwright-core": {
             "version": "1.58.2",
             "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
@@ -11148,9 +10656,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+            "version": "8.5.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
             "dev": true,
             "funding": [
                 {
@@ -11177,9 +10685,9 @@
             }
         },
         "node_modules/postcss/node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
             "dev": true,
             "funding": [
                 {
@@ -11232,34 +10740,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/pretty-format": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^18.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/pretty-format/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/pretty-ms": {
@@ -11552,13 +11032,6 @@
                 "rc": "cli.js"
             }
         },
-        "node_modules/react-is": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/readable-stream": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -11771,49 +11244,38 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/rollup": {
-            "version": "4.59.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-            "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+        "node_modules/rolldown": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
+            "integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/estree": "1.0.8"
+                "@oxc-project/types": "=0.129.0",
+                "@rolldown/pluginutils": "1.0.0"
             },
             "bin": {
-                "rollup": "dist/bin/rollup"
+                "rolldown": "bin/cli.mjs"
             },
             "engines": {
-                "node": ">=18.0.0",
-                "npm": ">=8.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.59.0",
-                "@rollup/rollup-android-arm64": "4.59.0",
-                "@rollup/rollup-darwin-arm64": "4.59.0",
-                "@rollup/rollup-darwin-x64": "4.59.0",
-                "@rollup/rollup-freebsd-arm64": "4.59.0",
-                "@rollup/rollup-freebsd-x64": "4.59.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-                "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-                "@rollup/rollup-linux-arm64-musl": "4.59.0",
-                "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-                "@rollup/rollup-linux-loong64-musl": "4.59.0",
-                "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-                "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-                "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-                "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-                "@rollup/rollup-linux-x64-gnu": "4.59.0",
-                "@rollup/rollup-linux-x64-musl": "4.59.0",
-                "@rollup/rollup-openbsd-x64": "4.59.0",
-                "@rollup/rollup-openharmony-arm64": "4.59.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-                "@rollup/rollup-win32-x64-gnu": "4.59.0",
-                "@rollup/rollup-win32-x64-msvc": "4.59.0",
-                "fsevents": "~2.3.2"
+                "@rolldown/binding-android-arm64": "1.0.0",
+                "@rolldown/binding-darwin-arm64": "1.0.0",
+                "@rolldown/binding-darwin-x64": "1.0.0",
+                "@rolldown/binding-freebsd-x64": "1.0.0",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0",
+                "@rolldown/binding-linux-x64-musl": "1.0.0",
+                "@rolldown/binding-openharmony-arm64": "1.0.0",
+                "@rolldown/binding-wasm32-wasi": "1.0.0",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0"
             }
         },
         "node_modules/router": {
@@ -12354,7 +11816,8 @@
             "version": "3.10.0",
             "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
             "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/stdin-discarder": {
             "version": "0.3.1",
@@ -12546,19 +12009,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/strip-final-newline": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/strip-json-comments": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -12567,19 +12017,6 @@
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/strip-literal": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
-            "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "js-tokens": "^9.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/strnum": {
@@ -12681,6 +12118,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/tinyexec": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+            "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.16",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -12698,20 +12145,10 @@
                 "url": "https://github.com/sponsors/SuperchupuDev"
             }
         },
-        "node_modules/tinypool": {
-            "version": "0.8.4",
-            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
-            "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/tinyspy": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
-            "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12788,8 +12225,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD",
-            "peer": true
+            "license": "0BSD"
         },
         "node_modules/tslog": {
             "version": "4.10.2",
@@ -12825,16 +12261,6 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/type-detect": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-            "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/type-is": {
@@ -12896,13 +12322,6 @@
             "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
             "license": "MIT",
             "peer": true
-        },
-        "node_modules/ufo": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-            "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/uhyphen": {
             "version": "0.2.0",
@@ -13019,21 +12438,23 @@
             }
         },
         "node_modules/vite": {
-            "version": "5.4.21",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-            "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+            "version": "8.0.12",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
+            "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "esbuild": "^0.21.3",
-                "postcss": "^8.4.43",
-                "rollup": "^4.20.0"
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.4",
+                "postcss": "^8.5.14",
+                "rolldown": "1.0.0",
+                "tinyglobby": "^0.2.16"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": "^18.0.0 || >=20.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "funding": {
                 "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -13042,23 +12463,33 @@
                 "fsevents": "~2.3.3"
             },
             "peerDependencies": {
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "less": "*",
-                "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
-                "terser": "^5.4.0"
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.1.18",
+                "esbuild": "^0.27.0 || ^0.28.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
             },
             "peerDependenciesMeta": {
                 "@types/node": {
                     "optional": true
                 },
-                "less": {
+                "@vitejs/devtools": {
                     "optional": true
                 },
-                "lightningcss": {
+                "esbuild": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
                     "optional": true
                 },
                 "sass": {
@@ -13075,85 +12506,89 @@
                 },
                 "terser": {
                     "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
                 }
             }
         },
-        "node_modules/vite-node": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
-            "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cac": "^6.7.14",
-                "debug": "^4.3.4",
-                "pathe": "^1.1.1",
-                "picocolors": "^1.0.0",
-                "vite": "^5.0.0"
-            },
-            "bin": {
-                "vite-node": "vite-node.mjs"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/vitest"
-            }
-        },
         "node_modules/vitest": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
-            "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+            "version": "4.1.6",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+            "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "1.6.1",
-                "@vitest/runner": "1.6.1",
-                "@vitest/snapshot": "1.6.1",
-                "@vitest/spy": "1.6.1",
-                "@vitest/utils": "1.6.1",
-                "acorn-walk": "^8.3.2",
-                "chai": "^4.3.10",
-                "debug": "^4.3.4",
-                "execa": "^8.0.1",
-                "local-pkg": "^0.5.0",
-                "magic-string": "^0.30.5",
-                "pathe": "^1.1.1",
-                "picocolors": "^1.0.0",
-                "std-env": "^3.5.0",
-                "strip-literal": "^2.0.0",
-                "tinybench": "^2.5.1",
-                "tinypool": "^0.8.3",
-                "vite": "^5.0.0",
-                "vite-node": "1.6.1",
-                "why-is-node-running": "^2.2.2"
+                "@vitest/expect": "4.1.6",
+                "@vitest/mocker": "4.1.6",
+                "@vitest/pretty-format": "4.1.6",
+                "@vitest/runner": "4.1.6",
+                "@vitest/snapshot": "4.1.6",
+                "@vitest/spy": "4.1.6",
+                "@vitest/utils": "4.1.6",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
             },
             "bin": {
                 "vitest": "vitest.mjs"
             },
             "engines": {
-                "node": "^18.0.0 || >=20.0.0"
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
                 "@edge-runtime/vm": "*",
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "@vitest/browser": "1.6.1",
-                "@vitest/ui": "1.6.1",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.6",
+                "@vitest/browser-preview": "4.1.6",
+                "@vitest/browser-webdriverio": "4.1.6",
+                "@vitest/coverage-istanbul": "4.1.6",
+                "@vitest/coverage-v8": "4.1.6",
+                "@vitest/ui": "4.1.6",
                 "happy-dom": "*",
-                "jsdom": "*"
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
             },
             "peerDependenciesMeta": {
                 "@edge-runtime/vm": {
                     "optional": true
                 },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
                 "@types/node": {
                     "optional": true
                 },
-                "@vitest/browser": {
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
                     "optional": true
                 },
                 "@vitest/ui": {
@@ -13164,8 +12599,18 @@
                 },
                 "jsdom": {
                     "optional": true
+                },
+                "vite": {
+                    "optional": false
                 }
             }
+        },
+        "node_modules/vitest/node_modules/std-env": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/web-streams-polyfill": {
             "version": "3.3.3",
@@ -13561,19 +13006,6 @@
             "dependencies": {
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"
-            }
-        },
-        "node_modules/yocto-queue": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
-            "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/yoctocolors": {

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -60,6 +60,6 @@
         "prettier": "^3.0.0",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.0.0",
-        "vitest": "^1.6.1"
+        "vitest": "^4.0.0"
     }
 }


### PR DESCRIPTION
## Summary

Bumps `vitest` in `integrations/openclaw/` from `^1.6.1` to `^4.0.0` (resolved to v4.1.6). Closes the 4 transitive advisories in vitest's dev-tree (`vitest → vite-node → vite → esbuild`) flagged by `npm audit` since PR-A's first install pass.

**Dev-toolchain-only change.** `vitest` is in `devDependencies` and never ships to npm consumers. No protocol changes, no runtime behavior changes, no version bump for the published `pic-guard` package.

Third and final PR of the post-Silver cleanup cluster:
- **PR-C (#83):** F1 + F6 + F7 hygiene tweaks — merged
- **PR-D (#84):** F8 GitHub Actions Node-24 transition — merged
- **PR-E (this PR):** F2 vitest v4 bump

## Changes

`integrations/openclaw/package.json`:
```diff
-        "vitest": "^1.6.1"
+        "vitest": "^4.0.0"
```

`integrations/openclaw/package-lock.json`: regenerated by `npm install`. Net change: **+764 / -1332 lines** (lockfile actually *shrinks* — vitest v4 simplified some transitives compared to the v1.6.1 tree).

## Verification (run locally before push)

All four gates passed cleanly:

| Gate | Result |
|---|---|
| `npm install` | exit 0; 22 packages added, 44 removed, 13 changed |
| `npx vitest run` | **14/14 tests pass on vitest v4.1.6** (same count as v1.6.1; same stderr lines from the malformed-response tests, which are expected) |
| `npx tsc --noEmit` | silent success — no type errors after the dep-tree shift |
| `npm audit` | **26 → 22 advisories** — exactly the 4 vitest-chain ones (`esbuild`, `vite`, `vite-node`, `vitest`) are gone |

## Why v4 (not v2 or v3)

Skipping intermediate majors closes all 4 vitest-chain advisories in one move. Our test files (`lib/pic-client.test.ts`, `lib/smoke.test.ts`) use only stable vitest APIs (`describe`, `it`, `expect`, `vi.fn`, `vi.stubGlobal`, `vi.unstubAllGlobals`, `vi.mocked`, `beforeEach`, `afterEach`) — none of these broke across v1→v2→v3→v4. Vitest's v4 release post itself notes that "for most users, breaking changes should not be noticeable unless you rely on advanced features."

## Remaining audit findings (out of scope)

The remaining 22 advisories are all in the OpenClaw peer-dependency tree (`axios`, `hono`, `@whiskeysockets/baileys`/`protobufjs`, `fast-xml-parser`, etc.). These flow through pic-guard's `peerDependencies: openclaw` declaration and are not pic-guard's own deps — they're upstream's tree.

These are tracked separately under follow-up **F3** (OpenClaw peer-tree audit triage). The right response is to wait for an OpenClaw upstream release that pins safer transitives, then bump `peerDependencies.openclaw` floor. Not addressed in this PR.

One transient observation: after the vitest bump, npm's audit now lists `@protobufjs/utf8` as a distinct entry (in addition to `protobufjs` itself). Likely a sub-package now flagged with its own GHSA. Still in the openclaw peer-tree, not vitest-related. F3 triage scope.

## Test plan

- [ ] CI passes on this branch (5 status checks: test-python × 4 + test-openclaw)
- [ ] `test-openclaw` job specifically runs vitest v4 and passes
- [ ] After merge: confirm `npm install` + `npx vitest run` in a fresh clone still works (smoke test)

No version bump for the published `pic-guard` package, no CHANGELOG entry, no release. Mention will land in the v0.8.2 CHANGELOG entry under "Notes" alongside the rest of the cluster.
