### PR TITLE
feat(conformance): trust-sanitization mode + 24 matrix vectors (v0.8.2 PR 2)

### DIFF
--- a/conformance/manifest.json
+++ b/conformance/manifest.json
@@ -260,6 +260,96 @@
       "mode": "trust_sanitization",
       "expected": "allow",
       "matrix_id": "financial_hash_ok"
+    },
+    {
+      "id": "trust-financial_irreversible-strict-f-verify-f",
+      "file": "trust_sanitization/financial_irreversible__strict-f__verify-f.json",
+      "mode": "trust_sanitization",
+      "expected": "allow",
+      "matrix_id": "financial_irreversible"
+    },
+    {
+      "id": "trust-financial_irreversible-strict-f-verify-t",
+      "file": "trust_sanitization/financial_irreversible__strict-f__verify-t.json",
+      "mode": "trust_sanitization",
+      "expected": "allow",
+      "matrix_id": "financial_irreversible"
+    },
+    {
+      "id": "trust-financial_irreversible-strict-t-verify-f",
+      "file": "trust_sanitization/financial_irreversible__strict-t__verify-f.json",
+      "mode": "trust_sanitization",
+      "expected": "block",
+      "expected_error_code": "PIC_VERIFIER_FAILED",
+      "matrix_id": "financial_irreversible"
+    },
+    {
+      "id": "trust-financial_irreversible-strict-t-verify-t",
+      "file": "trust_sanitization/financial_irreversible__strict-t__verify-t.json",
+      "mode": "trust_sanitization",
+      "expected": "block",
+      "expected_error_code": "PIC_VERIFIER_FAILED",
+      "matrix_id": "financial_irreversible"
+    },
+    {
+      "id": "trust-privacy_risk-strict-f-verify-f",
+      "file": "trust_sanitization/privacy_risk__strict-f__verify-f.json",
+      "mode": "trust_sanitization",
+      "expected": "allow",
+      "matrix_id": "privacy_risk"
+    },
+    {
+      "id": "trust-privacy_risk-strict-f-verify-t",
+      "file": "trust_sanitization/privacy_risk__strict-f__verify-t.json",
+      "mode": "trust_sanitization",
+      "expected": "allow",
+      "matrix_id": "privacy_risk"
+    },
+    {
+      "id": "trust-privacy_risk-strict-t-verify-f",
+      "file": "trust_sanitization/privacy_risk__strict-t__verify-f.json",
+      "mode": "trust_sanitization",
+      "expected": "block",
+      "expected_error_code": "PIC_VERIFIER_FAILED",
+      "matrix_id": "privacy_risk"
+    },
+    {
+      "id": "trust-privacy_risk-strict-t-verify-t",
+      "file": "trust_sanitization/privacy_risk__strict-t__verify-t.json",
+      "mode": "trust_sanitization",
+      "expected": "block",
+      "expected_error_code": "PIC_VERIFIER_FAILED",
+      "matrix_id": "privacy_risk"
+    },
+    {
+      "id": "trust-robotic_action-strict-f-verify-f",
+      "file": "trust_sanitization/robotic_action__strict-f__verify-f.json",
+      "mode": "trust_sanitization",
+      "expected": "allow",
+      "matrix_id": "robotic_action"
+    },
+    {
+      "id": "trust-robotic_action-strict-f-verify-t",
+      "file": "trust_sanitization/robotic_action__strict-f__verify-t.json",
+      "mode": "trust_sanitization",
+      "expected": "allow",
+      "matrix_id": "robotic_action"
+    },
+    {
+      "id": "trust-robotic_action-strict-t-verify-f",
+      "file": "trust_sanitization/robotic_action__strict-t__verify-f.json",
+      "mode": "trust_sanitization",
+      "expected": "block",
+      "expected_error_code": "PIC_VERIFIER_FAILED",
+      "matrix_id": "robotic_action"
+    },
+    {
+      "id": "trust-robotic_action-strict-t-verify-t",
+      "file": "trust_sanitization/robotic_action__strict-t__verify-t.json",
+      "mode": "trust_sanitization",
+      "expected": "block",
+      "expected_error_code": "PIC_VERIFIER_FAILED",
+      "matrix_id": "robotic_action"
     }
   ]
 }

--- a/conformance/manifest.json
+++ b/conformance/manifest.json
@@ -174,6 +174,13 @@
       "file": "evidence/allow/004_mixed_hash_and_sig.json",
       "mode": "evidence",
       "expected": "allow"
+    },
+    {
+      "id": "trust-compute_risk-strict-f-verify-f",
+      "file": "trust_sanitization/compute_risk__strict-f__verify-f.json",
+      "mode": "trust_sanitization",
+      "expected": "allow",
+      "matrix_id": "compute_risk"
     }
   ]
 }

--- a/conformance/manifest.json
+++ b/conformance/manifest.json
@@ -230,6 +230,36 @@
       "mode": "trust_sanitization",
       "expected": "allow",
       "matrix_id": "read_only_query"
+    },
+    {
+      "id": "trust-financial_hash_ok-strict-f-verify-f",
+      "file": "trust_sanitization/financial_hash_ok__strict-f__verify-f.json",
+      "mode": "trust_sanitization",
+      "expected": "block",
+      "expected_error_code": "PIC_VERIFIER_FAILED",
+      "matrix_id": "financial_hash_ok"
+    },
+    {
+      "id": "trust-financial_hash_ok-strict-f-verify-t",
+      "file": "trust_sanitization/financial_hash_ok__strict-f__verify-t.json",
+      "mode": "trust_sanitization",
+      "expected": "allow",
+      "matrix_id": "financial_hash_ok"
+    },
+    {
+      "id": "trust-financial_hash_ok-strict-t-verify-f",
+      "file": "trust_sanitization/financial_hash_ok__strict-t__verify-f.json",
+      "mode": "trust_sanitization",
+      "expected": "block",
+      "expected_error_code": "PIC_VERIFIER_FAILED",
+      "matrix_id": "financial_hash_ok"
+    },
+    {
+      "id": "trust-financial_hash_ok-strict-t-verify-t",
+      "file": "trust_sanitization/financial_hash_ok__strict-t__verify-t.json",
+      "mode": "trust_sanitization",
+      "expected": "allow",
+      "matrix_id": "financial_hash_ok"
     }
   ]
 }

--- a/conformance/manifest.json
+++ b/conformance/manifest.json
@@ -181,6 +181,55 @@
       "mode": "trust_sanitization",
       "expected": "allow",
       "matrix_id": "compute_risk"
+    },
+    {
+      "id": "trust-compute_risk-strict-f-verify-t",
+      "file": "trust_sanitization/compute_risk__strict-f__verify-t.json",
+      "mode": "trust_sanitization",
+      "expected": "allow",
+      "matrix_id": "compute_risk"
+    },
+    {
+      "id": "trust-compute_risk-strict-t-verify-f",
+      "file": "trust_sanitization/compute_risk__strict-t__verify-f.json",
+      "mode": "trust_sanitization",
+      "expected": "allow",
+      "matrix_id": "compute_risk"
+    },
+    {
+      "id": "trust-compute_risk-strict-t-verify-t",
+      "file": "trust_sanitization/compute_risk__strict-t__verify-t.json",
+      "mode": "trust_sanitization",
+      "expected": "allow",
+      "matrix_id": "compute_risk"
+    },
+    {
+      "id": "trust-read_only_query-strict-f-verify-f",
+      "file": "trust_sanitization/read_only_query__strict-f__verify-f.json",
+      "mode": "trust_sanitization",
+      "expected": "allow",
+      "matrix_id": "read_only_query"
+    },
+    {
+      "id": "trust-read_only_query-strict-f-verify-t",
+      "file": "trust_sanitization/read_only_query__strict-f__verify-t.json",
+      "mode": "trust_sanitization",
+      "expected": "allow",
+      "matrix_id": "read_only_query"
+    },
+    {
+      "id": "trust-read_only_query-strict-t-verify-f",
+      "file": "trust_sanitization/read_only_query__strict-t__verify-f.json",
+      "mode": "trust_sanitization",
+      "expected": "allow",
+      "matrix_id": "read_only_query"
+    },
+    {
+      "id": "trust-read_only_query-strict-t-verify-t",
+      "file": "trust_sanitization/read_only_query__strict-t__verify-t.json",
+      "mode": "trust_sanitization",
+      "expected": "allow",
+      "matrix_id": "read_only_query"
     }
   ]
 }

--- a/conformance/run.py
+++ b/conformance/run.py
@@ -4,8 +4,9 @@ Executes the conformance vectors declared in ``conformance/manifest.json``
 against the Python reference implementation and reports pass/fail.
 
 First pass: canonicalization and core modes. Evidence mode added in v0.8.2
-(see ``conformance/evidence/README.md``). Trust-sanitization mode and
-cross-implementation runners follow in subsequent v0.8.2 PRs per the v0.8.2
+(see ``conformance/evidence/README.md``). Trust-sanitization mode added in
+v0.8.2 (see ``conformance/trust_sanitization/README.md``).
+Cross-implementation runners follow in subsequent v0.8.2 PRs per the v0.8.2
 release plan; see ``ROADMAP.md`` §1.2.
 
 Usage
@@ -29,9 +30,11 @@ The runner rejects any manifest entry with fields outside the strict
 whitelist for its ``(mode, expected)`` tuple, and any ``mode`` /
 ``expected`` combination not declared in the schema. ``expected_error_code``
 (present on block entries for modes whose schema declares it) must be a
-non-empty string starting with ``PIC_``. This strictness is deliberate: a
-typo in the manifest should surface as a ``ManifestError`` at runner
-startup, not as a silently-passing vector.
+non-empty string starting with ``PIC_``; for ``trust_sanitization`` blocks
+it MUST be exactly ``"PIC_VERIFIER_FAILED"``. ``matrix_id`` (present on
+trust_sanitization entries) MUST be one of the 6 recognized matrix bases.
+This strictness is deliberate: a typo in the manifest should surface as a
+``ManifestError`` at runner startup, not as a silently-passing vector.
 
 Manifest-vector consistency
 ---------------------------
@@ -42,18 +45,25 @@ block vectors in modes that declare it). Drift between the manifest and
 the file is reported as a vector-level failure with a ``manifest/vector
 drift`` reason, not silently preferring one over the other.
 
+For ``trust_sanitization`` mode, the runner additionally enforces
+coordinate consistency: the vector ``id`` and manifest ``file`` MUST match
+the expected forms derived from ``matrix_id`` + the boolean coordinates in
+``options``. This prevents silent matrix corruption (a file named for one
+cell but containing the options of another).
+
 Warning handling
 ----------------
 The runner suppresses exactly one known-transitional warning class —
 ``pic_standard.pipeline.PICTrustFutureWarning`` — around the
-``verify_proposal()`` call for core-mode and evidence-mode vectors. Per
-``conformance/core/README.md``, warnings are language-specific and out of
-scope for shared portable vectors; leaving this particular warning
-unsuppressed would produce noise in CI logs during passing runs of
-``core-allow-002-trusted-money`` and similar legacy-trust/evidence vectors.
-All other warning classes are left unfiltered so that a future regression
-surfacing as a ``DeprecationWarning``, ``ResourceWarning``, or
-``RuntimeWarning`` is still visible to reviewers.
+``verify_proposal()`` call for core-mode, evidence-mode, and
+trust_sanitization-mode vectors. Per ``conformance/core/README.md``,
+warnings are language-specific and out of scope for shared portable
+vectors; leaving this particular warning unsuppressed would produce noise
+in CI logs during passing runs of ``core-allow-002-trusted-money`` and
+similar legacy-trust / evidence / trust-sanitization vectors. All other
+warning classes are left unfiltered so that a future regression surfacing
+as a ``DeprecationWarning``, ``ResourceWarning``, or ``RuntimeWarning`` is
+still visible to reviewers.
 """
 
 from __future__ import annotations
@@ -85,26 +95,54 @@ from pic_standard.pipeline import (  # noqa: E402
 # Schema constants
 # ---------------------------------------------------------------------------
 
-VALID_MODES = {"canonicalization", "core", "evidence"}
+VALID_MODES = {"canonicalization", "core", "evidence", "trust_sanitization"}
 
 EXPECTED_BY_MODE: Dict[str, set] = {
     "canonicalization": {"canonical_match"},
     "core": {"allow", "block"},
     "evidence": {"allow", "block"},
+    "trust_sanitization": {"allow", "block"},
 }
 
 MANIFEST_TOP_FIELDS = {"version", "vectors"}
 
+# Recognized trust-sanitization matrix bases. These correspond 1:1 to the
+# proposal bases in tests/test_trust_deprecation_warning.py::
+# VERDICT_REGRESSION_MATRIX. Manifest entries with mode="trust_sanitization"
+# MUST declare a matrix_id from this set; arbitrary strings are rejected at
+# manifest validation time.
+TRUST_SANITIZATION_MATRIX_IDS = {
+    "compute_risk",
+    "read_only_query",
+    "financial_hash_ok",
+    "financial_irreversible",
+    "privacy_risk",
+    "robotic_action",
+}
+
 # Exact fields allowed on a manifest vector entry, keyed by (mode, expected).
 # Anything outside the declared set triggers ManifestError.
-# Note: evidence-mode vector-internal fields (`options`, `proposal`,
-# `embedded_keyring`) live in the vector file, NOT the manifest entry.
+# Note: evidence-mode and trust_sanitization-mode vector-internal fields
+# (``options`` and ``proposal``) live in the vector file, NOT the manifest
+# entry. ``embedded_keyring`` is evidence-mode only and is rejected for
+# trust_sanitization vectors. ``matrix_id`` is a trust_sanitization-only
+# manifest field that groups vectors by the proposal-base they were lifted
+# from in tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX.
 ENTRY_FIELDS: Dict[tuple, set] = {
     ("canonicalization", "canonical_match"): {"id", "file", "mode", "expected"},
     ("core", "allow"): {"id", "file", "mode", "expected"},
     ("core", "block"): {"id", "file", "mode", "expected", "expected_error_code"},
     ("evidence", "allow"): {"id", "file", "mode", "expected"},
     ("evidence", "block"): {"id", "file", "mode", "expected", "expected_error_code"},
+    ("trust_sanitization", "allow"): {"id", "file", "mode", "expected", "matrix_id"},
+    ("trust_sanitization", "block"): {
+        "id",
+        "file",
+        "mode",
+        "expected",
+        "expected_error_code",
+        "matrix_id",
+    },
 }
 
 
@@ -246,14 +284,38 @@ def _validate_entry(entry: Any) -> None:
             f"missing fields {sorted(missing)} for (mode={mode!r}, expected={expected!r})"
         )
 
-    # `expected_error_code` validation generalizes over any (mode, expected)
-    # whose ENTRY_FIELDS schema includes the field. Extends cleanly to evidence
-    # and future modes without re-touching this branch.
+    # `expected_error_code` general validation: any (mode, expected) whose
+    # ENTRY_FIELDS schema includes the field requires a non-empty PIC_* string.
     if "expected_error_code" in allowed_fields:
         ec = entry["expected_error_code"]
         if not isinstance(ec, str) or not ec.startswith("PIC_"):
             raise ManifestError(
                 f"expected_error_code must be a non-empty string starting with 'PIC_', got {ec!r}"
+            )
+
+    # `matrix_id` general validation: any (mode, expected) whose ENTRY_FIELDS
+    # schema includes the field requires a non-empty string.
+    if "matrix_id" in allowed_fields:
+        mid = entry["matrix_id"]
+        if not isinstance(mid, str) or not mid:
+            raise ManifestError(f"matrix_id must be a non-empty string, got {mid!r}")
+
+    # Trust-sanitization-specific tightening:
+    # 1. matrix_id MUST be one of the 6 recognized matrix bases.
+    # 2. block entries MUST use exactly PIC_VERIFIER_FAILED — the matrix's
+    #    contract is that all trust-sanitization blocks are verifier-layer
+    #    blocks. Any other error code is an authoring mistake.
+    if mode == "trust_sanitization":
+        if entry["matrix_id"] not in TRUST_SANITIZATION_MATRIX_IDS:
+            raise ManifestError(
+                f"matrix_id {entry['matrix_id']!r} is not a recognized trust-sanitization "
+                f"matrix base (allowed: {sorted(TRUST_SANITIZATION_MATRIX_IDS)})"
+            )
+        if expected == "block" and entry["expected_error_code"] != "PIC_VERIFIER_FAILED":
+            raise ManifestError(
+                "trust_sanitization block entries must use "
+                "expected_error_code='PIC_VERIFIER_FAILED', got "
+                f"{entry['expected_error_code']!r}"
             )
 
 
@@ -272,10 +334,11 @@ def _check_vector_file_agrees_with_entry(
     if the file and manifest agree. Callers should turn a non-None return
     into a per-vector failure rather than silently proceeding.
 
-    Applies to core-mode and evidence-mode vectors (both carry `expected` and
-    optionally `expected_error_code` inside the vector file). Canonicalization
-    vector files do not carry duplicate `expected` / `expected_error_code`
-    fields, so there is nothing to cross-check at that layer beyond the id.
+    Applies to core-mode, evidence-mode, and trust_sanitization-mode vectors
+    (all three carry `expected` and optionally `expected_error_code` inside
+    the vector file). Canonicalization vector files do not carry duplicate
+    `expected` / `expected_error_code` fields, so there is nothing to
+    cross-check at that layer beyond the id.
 
     Mode drift (v0.8.2+):
       - If a vector file declares `mode` and it disagrees with the manifest
@@ -283,9 +346,11 @@ def _check_vector_file_agrees_with_entry(
         This generic check runs for ALL modes — a canonicalization vector
         with a wrong `mode` declaration would still drift.
       - Evidence-mode vector files MUST declare `mode: "evidence"` per
-        ``conformance/evidence/README.md``. Existing core-mode vector files
-        do NOT declare `mode` and are not required to; backward compat
-        preserved.
+        ``conformance/evidence/README.md``. Trust_sanitization-mode vector
+        files MUST declare `mode: "trust_sanitization"` per
+        ``conformance/trust_sanitization/README.md``. Existing core-mode
+        vector files do NOT declare `mode` and are not required to;
+        backward compat preserved.
     """
     mode = entry["mode"]
 
@@ -295,7 +360,7 @@ def _check_vector_file_agrees_with_entry(
     if "mode" in vec and vec["mode"] != entry["mode"]:
         return f"'mode' mismatch: manifest={entry['mode']!r} file={vec['mode']!r}"
 
-    if mode not in ("core", "evidence"):
+    if mode not in ("core", "evidence", "trust_sanitization"):
         return None
 
     # Evidence-mode vector files MUST declare `mode: "evidence"` explicitly.
@@ -303,6 +368,11 @@ def _check_vector_file_agrees_with_entry(
     # them through as long as no wrong `mode` is declared.)
     if mode == "evidence" and vec.get("mode") != "evidence":
         return "evidence vector file must declare mode='evidence'"
+
+    # Trust_sanitization-mode vector files MUST declare
+    # `mode: "trust_sanitization"` explicitly.
+    if mode == "trust_sanitization" and vec.get("mode") != "trust_sanitization":
+        return "trust_sanitization vector file must declare mode='trust_sanitization'"
 
     vec_expected = vec.get("expected")
     if vec_expected != entry["expected"]:
@@ -788,6 +858,299 @@ def _run_evidence_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorRe
 
 
 # ---------------------------------------------------------------------------
+# Trust-sanitization-mode dispatch (v0.8.2 PR V8.2-2)
+# ---------------------------------------------------------------------------
+
+
+def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorResult:
+    """Run a trust-sanitization-mode vector through verify_proposal().
+
+    Parallel structure to `_run_evidence_vector` but tuned for the
+    trust-sanitization conformance surface (see
+    ``conformance/trust_sanitization/README.md``):
+
+      - The vector's `options` MUST declare both `strict_trust` and
+        `verify_evidence` explicitly AS JSON BOOLEANS. The matrix
+        coordinate is encoded in these options; defaults or stringly-typed
+        values would make the vector ambiguous.
+      - Rejects `key_resolver` and `proposal_base_dir` in options (same
+        portability principle as evidence mode — runner-controlled fields
+        cannot be smuggled through JSON).
+      - Rejects non-dict `proposal` values fail-closed.
+      - Trust-sanitization vectors MUST NOT carry sig evidence (the
+        regression matrix excludes financial_sig_ok.json). The runner
+        rejects sig-evidence proposals fail-closed in this mode to prevent
+        falling back to PIC_KEYS_PATH / default keyring resolution.
+        Authors who need sig-evidence coverage should use evidence mode.
+      - Rejects top-level `embedded_keyring`. In this mode it would be
+        silently ignored (no sig evidence), which would mislead reviewers
+        about hermeticity.
+      - Enforces coordinate consistency: the vector `id` and manifest
+        `file` MUST be derivable from `matrix_id` + the boolean
+        coordinates. Catches silent matrix corruption (a file named for
+        one cell but containing the options of another).
+      - Reuses the evidence-mode helpers for `evidence_root_dir`
+        resolution and `proposal_base_dir` derivation. This matters for
+        the `financial_hash_ok` matrix cells which contain file-backed
+        hash evidence; other matrix cells (low-impact,
+        self-asserted-trusted high-impact) have no evidence and the
+        resolution is a no-op.
+      - Suppresses PICTrustFutureWarning around the verify_proposal call
+        (same as core/evidence modes).
+    """
+    vid = vec["id"]
+    if "proposal" not in vec:
+        return VectorResult(
+            id=vid,
+            mode="trust_sanitization",
+            passed=False,
+            reason="vector file missing required field: 'proposal'",
+        )
+
+    # Options must be present as an object. The matrix coordinate
+    # (strict_trust, verify_evidence) is mandatory; relying on defaults
+    # would make the vector ambiguous about which cell it tests.
+    if "options" not in vec or not isinstance(vec["options"], dict):
+        return VectorResult(
+            id=vid,
+            mode="trust_sanitization",
+            passed=False,
+            reason="trust_sanitization vector missing required object field: 'options'",
+        )
+
+    options_dict = vec["options"]
+
+    # Require both matrix-axis settings to be present (no implicit defaults).
+    if "strict_trust" not in options_dict:
+        return VectorResult(
+            id=vid,
+            mode="trust_sanitization",
+            passed=False,
+            reason="trust_sanitization vector must declare options.strict_trust",
+        )
+    if "verify_evidence" not in options_dict:
+        return VectorResult(
+            id=vid,
+            mode="trust_sanitization",
+            passed=False,
+            reason="trust_sanitization vector must declare options.verify_evidence",
+        )
+
+    # Both matrix axes MUST be actual booleans. JSON true/false → Python bool.
+    # Without this guard, a stringly-typed "false" or numeric 0 would pass
+    # the presence check above and silently represent a matrix coordinate
+    # the vector did not actually intend.
+    if not isinstance(options_dict["strict_trust"], bool):
+        return VectorResult(
+            id=vid,
+            mode="trust_sanitization",
+            passed=False,
+            reason="trust_sanitization vector options.strict_trust must be boolean",
+        )
+    if not isinstance(options_dict["verify_evidence"], bool):
+        return VectorResult(
+            id=vid,
+            mode="trust_sanitization",
+            passed=False,
+            reason="trust_sanitization vector options.verify_evidence must be boolean",
+        )
+
+    # Reject smuggling of runner-controlled fields (same convention as
+    # evidence mode).
+    if "key_resolver" in options_dict:
+        return VectorResult(
+            id=vid,
+            mode="trust_sanitization",
+            passed=False,
+            reason="trust_sanitization vector options must not declare key_resolver",
+        )
+    if "proposal_base_dir" in options_dict:
+        return VectorResult(
+            id=vid,
+            mode="trust_sanitization",
+            passed=False,
+            reason=(
+                "trust_sanitization vector options must not declare proposal_base_dir; "
+                "the runner derives it from evidence_root_dir"
+            ),
+        )
+
+    # Coordinate consistency check: the vector id and manifest file path
+    # MUST be derivable from matrix_id + boolean coordinates. Catches a real
+    # silent-corruption foot-gun: a file named compute_risk__strict-f__verify-f.json
+    # containing strict_trust=true would silently test the wrong matrix
+    # cell. Low-impact rows hide this (all 4 cells = allow) but high-impact
+    # rows would flip a real verdict.
+    strict_label = "t" if options_dict["strict_trust"] else "f"
+    verify_label = "t" if options_dict["verify_evidence"] else "f"
+    matrix_id = entry["matrix_id"]
+    expected_id = f"trust-{matrix_id}-strict-{strict_label}-verify-{verify_label}"
+    expected_file = (
+        f"trust_sanitization/{matrix_id}__strict-{strict_label}__verify-{verify_label}.json"
+    )
+    if vec["id"] != expected_id:
+        return VectorResult(
+            id=vid,
+            mode="trust_sanitization",
+            passed=False,
+            reason=(
+                f"coordinate/id mismatch: options imply id={expected_id!r}, "
+                f"vector file declares id={vec['id']!r}"
+            ),
+        )
+    if entry["file"] != expected_file:
+        return VectorResult(
+            id=vid,
+            mode="trust_sanitization",
+            passed=False,
+            reason=(
+                f"coordinate/file mismatch: options imply file={expected_file!r}, "
+                f"manifest declares file={entry['file']!r}"
+            ),
+        )
+
+    # Reject top-level embedded_keyring. In this mode it would be silently
+    # ignored (no sig evidence), which would mislead reviewers into thinking
+    # keyring hermeticity is being enforced. Authors who need sig-evidence
+    # coverage with an embedded keyring should use evidence mode.
+    if "embedded_keyring" in vec:
+        return VectorResult(
+            id=vid,
+            mode="trust_sanitization",
+            passed=False,
+            reason=(
+                "trust_sanitization vectors must not declare embedded_keyring; "
+                "use evidence mode for signature-evidence conformance"
+            ),
+        )
+
+    proposal = vec["proposal"]
+
+    if not isinstance(proposal, dict):
+        return VectorResult(
+            id=vid,
+            mode="trust_sanitization",
+            passed=False,
+            reason="vector file field 'proposal' must be an object",
+        )
+
+    # Reject sig evidence in trust_sanitization mode. This mode does NOT
+    # handle embedded_keyring (no sig vectors are in the regression matrix),
+    # so a sig-evidence proposal would reach verify_proposal() with no
+    # keyring plumbing and fall back to PIC_KEYS_PATH / default-keyring
+    # resolution — re-opening the env-var fallback hole that evidence-mode
+    # explicitly closes. Authors who need sig-evidence coverage should use
+    # evidence mode (conformance/evidence/README.md).
+    if _proposal_contains_sig_evidence(proposal):
+        return VectorResult(
+            id=vid,
+            mode="trust_sanitization",
+            passed=False,
+            reason=(
+                "trust_sanitization vectors must not contain sig evidence; "
+                "use evidence mode for signature-evidence conformance"
+            ),
+        )
+
+    # Hermeticity guard for the financial_hash_ok matrix cells: if the
+    # proposal carries file-backed hash evidence, evidence_root_dir must
+    # be a non-empty string. Other matrix cells have no evidence and this
+    # guard is a no-op.
+    if _proposal_contains_file_hash_evidence(proposal):
+        erd = options_dict.get("evidence_root_dir")
+        if not isinstance(erd, str) or not erd:
+            return VectorResult(
+                id=vid,
+                mode="trust_sanitization",
+                passed=False,
+                reason=(
+                    "trust_sanitization vector with file-backed hash evidence must set "
+                    "non-empty string options.evidence_root_dir"
+                ),
+            )
+
+    # Resolve evidence_root_dir against repo root (reuses the evidence-mode
+    # helper; same invariants apply). No-op for vectors without
+    # evidence_root_dir.
+    try:
+        options_dict = _resolve_evidence_root_against_repo_root(options_dict)
+    except Exception as e:
+        return VectorResult(
+            id=vid,
+            mode="trust_sanitization",
+            passed=False,
+            reason=f"could not resolve evidence_root_dir: {type(e).__name__}: {e}",
+        )
+
+    # Derive proposal_base_dir from the resolved evidence_root_dir so
+    # file://<name> refs resolve under the configured artifact root.
+    if "evidence_root_dir" in options_dict:
+        options_dict = {
+            **options_dict,
+            "proposal_base_dir": options_dict["evidence_root_dir"],
+        }
+
+    try:
+        options = PipelineOptions(**options_dict)
+    except Exception as e:
+        return VectorResult(
+            id=vid,
+            mode="trust_sanitization",
+            passed=False,
+            reason=f"could not construct PipelineOptions: {type(e).__name__}: {e}",
+        )
+
+    try:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=PICTrustFutureWarning)
+            result = verify_proposal(proposal, options=options)
+    except Exception as e:
+        return VectorResult(
+            id=vid,
+            mode="trust_sanitization",
+            passed=False,
+            reason=f"verify_proposal() raised {type(e).__name__}: {e}",
+        )
+
+    if entry["expected"] == "allow":
+        if result.ok:
+            return VectorResult(id=vid, mode="trust_sanitization", passed=True)
+        code = result.error.code.value if (result.error and result.error.code) else "<none>"
+        return VectorResult(
+            id=vid,
+            mode="trust_sanitization",
+            passed=False,
+            reason=f"expected allow but got block ({code})",
+        )
+
+    # expected == "block"
+    if result.ok:
+        return VectorResult(
+            id=vid,
+            mode="trust_sanitization",
+            passed=False,
+            reason="expected block but proposal was allowed",
+        )
+    if result.error is None or result.error.code is None:
+        return VectorResult(
+            id=vid,
+            mode="trust_sanitization",
+            passed=False,
+            reason="expected block with error code, got block with no error code",
+        )
+    actual_code = result.error.code.value
+    expected_code = entry["expected_error_code"]
+    if actual_code != expected_code:
+        return VectorResult(
+            id=vid,
+            mode="trust_sanitization",
+            passed=False,
+            reason=f"expected {expected_code} but got {actual_code}",
+        )
+    return VectorResult(id=vid, mode="trust_sanitization", passed=True)
+
+
+# ---------------------------------------------------------------------------
 # Orchestrator
 # ---------------------------------------------------------------------------
 
@@ -869,6 +1232,8 @@ def run_manifest(manifest_path: Path) -> RunnerReport:
             report.results.append(_run_canonicalization_vector(vec))
         elif entry["mode"] == "evidence":
             report.results.append(_run_evidence_vector(vec, entry))
+        elif entry["mode"] == "trust_sanitization":
+            report.results.append(_run_trust_sanitization_vector(vec, entry))
         else:
             # core (default — preserved for backward compat with existing
             # manifest entries that don't declare evidence/trust_sanitization)
@@ -886,7 +1251,8 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(
         prog="python -m conformance.run",
         description=(
-            "PIC Conformance Runner v0.1 — executes canonicalization, core, and evidence vectors."
+            "PIC Conformance Runner v0.1 — executes canonicalization, core, "
+            "evidence, and trust_sanitization vectors."
         ),
     )
     parser.add_argument(

--- a/conformance/trust_sanitization/README.md
+++ b/conformance/trust_sanitization/README.md
@@ -1,0 +1,203 @@
+# Trust-sanitization conformance vectors
+
+Portable conformance vectors that pin the verifier's `strict_trust` semantics
+across the matrix of `(proposal_base × strict_trust × verify_evidence)`. Each
+vector codifies one cell of the `VERDICT_REGRESSION_MATRIX` already pinned
+in-tree by [`tests/test_trust_deprecation_warning.py`](../../tests/test_trust_deprecation_warning.py),
+making the same behavior verifiable by any conformant implementation (e.g., the
+TypeScript verifier in v0.9.0).
+
+The matrix tests two distinct enforcement behaviors of the verifier:
+
+- **Trust sanitization (`strict_trust=true`):** self-asserted `trust="trusted"`
+  on a provenance entry is FLATTENED to `untrusted` BEFORE evidence
+  verification and the verifier's causal-contract check. The only way to
+  get back to `trusted` under strict mode is via verifier-derived trust
+  (i.e., evidence verification that succeeds).
+- **Evidence-backed upgrade (`verify_evidence=true`):** valid evidence (hash
+  or signature) upgrades the matching provenance entry to `trusted` AFTER
+  any sanitization step.
+
+The 24-cell matrix exercises every combination of these two settings across
+6 representative proposal bases.
+
+## Matrix structure
+
+| Proposal base | strict-F verify-F | strict-F verify-T | strict-T verify-F | strict-T verify-T | Behavior |
+|---|---|---|---|---|---|
+| `compute_risk` | allow | allow | allow | allow | low-impact always allowed |
+| `read_only_query` | allow | allow | allow | allow | low-impact always allowed |
+| `financial_hash_ok` | block (VERIFIER_FAILED) | allow | block (VERIFIER_FAILED) | allow | money + untrusted prov + hash evidence; `verify_evidence` flips verdict |
+| `financial_irreversible` | allow | allow | block (VERIFIER_FAILED) | block (VERIFIER_FAILED) | money + self-asserted trusted; `strict_trust` flips verdict |
+| `privacy_risk` | allow | allow | block (VERIFIER_FAILED) | block (VERIFIER_FAILED) | privacy + self-asserted trusted; same shape as financial_irreversible |
+| `robotic_action` | allow | allow | block (VERIFIER_FAILED) | block (VERIFIER_FAILED) | irreversible + self-asserted trusted; same shape as financial_irreversible |
+
+All 8 block cells use error code `PIC_VERIFIER_FAILED` (the verifier's
+causal-contract check rejects the proposal after model instantiation).
+
+The intended 24 trust-sanitization matrix cells do not use
+`PIC_EVIDENCE_FAILED`. When they block, they block with
+`PIC_VERIFIER_FAILED` because the verifier's causal-contract check rejects
+the proposal after trust sanitization / evidence upgrade has completed.
+Evidence-layer failures belong in the evidence-mode conformance surface;
+see [`conformance/evidence/README.md`](../evidence/README.md). (A
+malformed trust-sanitization vector — wrong SHA pin, missing artifact —
+could still produce `PIC_EVIDENCE_FAILED` at runtime; the matrix is
+designed not to, but "never" overstates runtime behavior.)
+
+## Layout
+
+```
+conformance/trust_sanitization/
+├── README.md                                            (this file)
+├── compute_risk__strict-f__verify-f.json
+├── compute_risk__strict-f__verify-t.json
+├── ... (24 files total, one per matrix cell)
+└── robotic_action__strict-t__verify-t.json
+```
+
+Files are named by matrix coordinates:
+`<matrix_id>__strict-<t|f>__verify-<t|f>.json`. The double underscore
+separator visually groups base / strict / verify. No `allow/` vs `block/`
+subdirectory split because every cell's verdict is determined by the
+coordinates, not the proposal alone.
+
+## Vector schema
+
+Each vector file is a JSON object with the following structure:
+
+```json
+{
+  "id": "trust-financial_hash_ok-strict-f-verify-t",
+  "description": "Trust-sanitization matrix cell: financial_hash_ok, strict_trust=false, verify_evidence=true.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (financial_hash_ok.json, strict=F, verify=T).",
+  "mode": "trust_sanitization",
+  "expected": "allow",
+  "options": {
+    "strict_trust": false,
+    "verify_evidence": true,
+    "evidence_root_dir": "conformance/artifacts"
+  },
+  "proposal": { /* full inline PIC/1.0 proposal */ }
+}
+```
+
+For `expected: "block"`, include `"expected_error_code": "PIC_VERIFIER_FAILED"`
+at the top level (sibling of `expected`).
+
+### Field reference
+
+| Field | Required | Description |
+|---|---|---|
+| `id` | yes | Stable identifier. The `trust-`, `strict-*`, and `verify-*` parts are kebab-style; the embedded `matrix_id` preserves the source proposal-base identifier, including underscores. Convention: `trust-<matrix_id>-strict-<t\|f>-verify-<t\|f>`. The runner enforces consistency with `options` coordinates — see **Coordinate consistency** below. |
+| `description` | yes | One-paragraph summary of the matrix cell. |
+| `source` | yes | Cross-reference to `tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX`. |
+| `mode` | yes | MUST be `"trust_sanitization"`. |
+| `expected` | yes | `"allow"` or `"block"`. |
+| `expected_error_code` | only when `expected == "block"` | MUST be exactly `"PIC_VERIFIER_FAILED"`. Enforced at manifest validation time. |
+| `options` | yes | Pipeline options as a JSON object. MUST declare `strict_trust` and `verify_evidence` as JSON booleans (not strings, not numbers). MUST NOT declare `key_resolver` or `proposal_base_dir`. For proposals with file-backed hash evidence, MUST also set `evidence_root_dir`. |
+| `proposal` | yes | Full inline PIC/1.0 Action Proposal. MUST NOT contain sig evidence — use evidence mode for signature-evidence coverage. |
+
+The vector file MUST NOT include a top-level `embedded_keyring` field. It
+would be silently ignored in this mode (no sig evidence), which would
+mislead reviewers into thinking keyring hermeticity is being enforced.
+
+### Options constraints
+
+Trust-sanitization vectors MUST declare `options` as a JSON object with
+both `strict_trust` and `verify_evidence` explicitly set to JSON booleans
+(`true` / `false`). String `"false"` or numeric `0` is rejected fail-closed
+by the runner — the matrix coordinate must be unambiguous.
+
+Vector JSON MUST NOT include `options.key_resolver` or
+`options.proposal_base_dir`. These are runner-controlled fields and
+cannot be represented portably in JSON (same convention as evidence-mode
+vectors).
+
+Vector JSON MUST NOT include sig evidence (`type: "sig"` evidence entries
+in the proposal). The regression matrix excludes signature evidence; the
+runner rejects sig-evidence proposals fail-closed in this mode to prevent
+falling back to `PIC_KEYS_PATH` / default keyring resolution. Authors who
+need sig-evidence coverage should use evidence mode.
+
+Vector JSON MUST NOT include a top-level `embedded_keyring` field. In
+this mode it would be ignored (trust-sanitization has no sig evidence),
+which would mislead reviewers into thinking keyring hermeticity is being
+enforced. The runner rejects it fail-closed.
+
+For proposals that contain file-backed hash evidence (the four
+`financial_hash_ok` cells), `options.evidence_root_dir` MUST be set to
+`"conformance/artifacts"` (or an equivalent repo-root-relative path
+inside that subtree). The runner derives `proposal_base_dir` from the
+resolved `evidence_root_dir` so `file://<name>` refs resolve under the
+configured artifact root. Proposals without file evidence may omit
+`evidence_root_dir`.
+
+### Coordinate consistency (LOCKED)
+
+The runner derives the expected vector `id` and manifest `file` from the
+`matrix_id` plus the boolean coordinates in `options`:
+
+```
+expected_id   = "trust-{matrix_id}-strict-{t|f}-verify-{t|f}"
+expected_file = "trust_sanitization/{matrix_id}__strict-{t|f}__verify-{t|f}.json"
+```
+
+The vector's `id` MUST match `expected_id`, and the manifest entry's
+`file` MUST match `expected_file`. This catches silent matrix corruption:
+a file named `compute_risk__strict-f__verify-f.json` that internally
+declares `strict_trust=true` would silently test the wrong cell — both
+its declared cell (FF) and its actual cell (TF) produce allow for
+`compute_risk`, but for `financial_irreversible` the same drift would
+flip a real verdict (FF→allow vs TF→block). The runner enforces
+consistency fail-closed.
+
+## Manifest entry
+
+Each vector has a manifest entry with a required `matrix_id` for grouping:
+
+```json
+{
+  "id": "trust-financial_hash_ok-strict-f-verify-t",
+  "file": "trust_sanitization/financial_hash_ok__strict-f__verify-t.json",
+  "mode": "trust_sanitization",
+  "expected": "allow",
+  "matrix_id": "financial_hash_ok"
+}
+```
+
+For `expected: "block"`, include `expected_error_code` at the manifest
+entry level (same as `core` and `evidence` block entries).
+
+Constraints (runner-enforced):
+
+- `matrix_id` MUST be one of the 6 recognized trust-sanitization matrix
+  bases: `compute_risk`, `read_only_query`, `financial_hash_ok`,
+  `financial_irreversible`, `privacy_risk`, `robotic_action`. Arbitrary
+  strings are rejected fail-closed at manifest validation time.
+- For `expected: "block"`, `expected_error_code` MUST be exactly
+  `"PIC_VERIFIER_FAILED"` — the matrix's contract is that all
+  trust-sanitization blocks are verifier-layer blocks. Any other error
+  code is rejected at manifest validation time.
+- `file` MUST match the expected path derived from `matrix_id` plus the
+  boolean coordinates in `options` (see **Coordinate consistency** above).
+
+## Cross-references
+
+- [`tests/test_trust_deprecation_warning.py`](../../tests/test_trust_deprecation_warning.py)
+  — the in-tree regression test (`VERDICT_REGRESSION_MATRIX`) that pins the
+  same behavior in Python. Every vector in this directory has a 1:1 row
+  mapping; portable vectors agree with regression-matrix rows for every
+  shared `(proposal_base, strict_trust, verify_evidence)` triple.
+- [`conformance/run.py`](../run.py) — the runner that dispatches
+  `trust_sanitization` mode vectors via `verify_proposal()`.
+- [`sdk-python/pic_standard/pipeline.py`](../../sdk-python/pic_standard/pipeline.py)
+  — `_sanitize_provenance_trust` + the verify_proposal pipeline that
+  implements strict-trust sanitization.
+- [`conformance/evidence/README.md`](../evidence/README.md) — the parallel
+  evidence-mode conformance surface (different mode, different error code
+  for block vectors, supports sig evidence + embedded_keyring).
+- [`docs/migration-trust-sanitization.md`](../../docs/migration-trust-sanitization.md)
+  — the v0.7.5 Trust Axiom migration guide that introduced `strict_trust`.
+- `docs/spec-core.md` (lands in PR V8.2-4) — normative spec these vectors
+  codify.

--- a/conformance/trust_sanitization/compute_risk__strict-f__verify-f.json
+++ b/conformance/trust_sanitization/compute_risk__strict-f__verify-f.json
@@ -1,0 +1,37 @@
+{
+  "id": "trust-compute_risk-strict-f-verify-f",
+  "description": "Trust-sanitization matrix cell: compute_risk, strict_trust=false, verify_evidence=false. Low-impact proposal is allowed regardless of trust mode.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (compute_risk.json, strict=F, verify=F).",
+  "mode": "trust_sanitization",
+  "expected": "allow",
+  "options": {
+    "strict_trust": false,
+    "verify_evidence": false
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Trigger Large-Scale Batch Simulation",
+    "impact": "compute",
+    "provenance": [
+      {
+        "id": "ops_dashboard_trigger",
+        "trust": "trusted"
+      }
+    ],
+    "claims": [
+      {
+        "text": "Triggered by verified Ops Dashboard",
+        "evidence": [
+          "ops_dashboard_trigger"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "aws.batch_run",
+      "args": {
+        "nodes": 100,
+        "duration_hours": 24
+      }
+    }
+  }
+}

--- a/conformance/trust_sanitization/compute_risk__strict-f__verify-t.json
+++ b/conformance/trust_sanitization/compute_risk__strict-f__verify-t.json
@@ -1,0 +1,37 @@
+{
+  "id": "trust-compute_risk-strict-f-verify-t",
+  "description": "Trust-sanitization matrix cell: compute_risk, strict_trust=false, verify_evidence=true. Low-impact proposal is allowed regardless of trust mode.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (compute_risk.json, strict=F, verify=T).",
+  "mode": "trust_sanitization",
+  "expected": "allow",
+  "options": {
+    "strict_trust": false,
+    "verify_evidence": true
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Trigger Large-Scale Batch Simulation",
+    "impact": "compute",
+    "provenance": [
+      {
+        "id": "ops_dashboard_trigger",
+        "trust": "trusted"
+      }
+    ],
+    "claims": [
+      {
+        "text": "Triggered by verified Ops Dashboard",
+        "evidence": [
+          "ops_dashboard_trigger"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "aws.batch_run",
+      "args": {
+        "nodes": 100,
+        "duration_hours": 24
+      }
+    }
+  }
+}

--- a/conformance/trust_sanitization/compute_risk__strict-t__verify-f.json
+++ b/conformance/trust_sanitization/compute_risk__strict-t__verify-f.json
@@ -1,0 +1,37 @@
+{
+  "id": "trust-compute_risk-strict-t-verify-f",
+  "description": "Trust-sanitization matrix cell: compute_risk, strict_trust=true, verify_evidence=false. Low-impact proposal is allowed regardless of trust mode.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (compute_risk.json, strict=T, verify=F).",
+  "mode": "trust_sanitization",
+  "expected": "allow",
+  "options": {
+    "strict_trust": true,
+    "verify_evidence": false
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Trigger Large-Scale Batch Simulation",
+    "impact": "compute",
+    "provenance": [
+      {
+        "id": "ops_dashboard_trigger",
+        "trust": "trusted"
+      }
+    ],
+    "claims": [
+      {
+        "text": "Triggered by verified Ops Dashboard",
+        "evidence": [
+          "ops_dashboard_trigger"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "aws.batch_run",
+      "args": {
+        "nodes": 100,
+        "duration_hours": 24
+      }
+    }
+  }
+}

--- a/conformance/trust_sanitization/compute_risk__strict-t__verify-t.json
+++ b/conformance/trust_sanitization/compute_risk__strict-t__verify-t.json
@@ -1,0 +1,37 @@
+{
+  "id": "trust-compute_risk-strict-t-verify-t",
+  "description": "Trust-sanitization matrix cell: compute_risk, strict_trust=true, verify_evidence=true. Low-impact proposal is allowed regardless of trust mode.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (compute_risk.json, strict=T, verify=T).",
+  "mode": "trust_sanitization",
+  "expected": "allow",
+  "options": {
+    "strict_trust": true,
+    "verify_evidence": true
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Trigger Large-Scale Batch Simulation",
+    "impact": "compute",
+    "provenance": [
+      {
+        "id": "ops_dashboard_trigger",
+        "trust": "trusted"
+      }
+    ],
+    "claims": [
+      {
+        "text": "Triggered by verified Ops Dashboard",
+        "evidence": [
+          "ops_dashboard_trigger"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "aws.batch_run",
+      "args": {
+        "nodes": 100,
+        "duration_hours": 24
+      }
+    }
+  }
+}

--- a/conformance/trust_sanitization/financial_hash_ok__strict-f__verify-f.json
+++ b/conformance/trust_sanitization/financial_hash_ok__strict-f__verify-f.json
@@ -1,0 +1,47 @@
+{
+  "id": "trust-financial_hash_ok-strict-f-verify-f",
+  "description": "Trust-sanitization matrix cell: financial_hash_ok, strict_trust=false, verify_evidence=false. Money-impact proposal with untrusted provenance is rejected by the verifier when evidence verification is not run.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (financial_hash_ok.json, strict=F, verify=F).",
+  "mode": "trust_sanitization",
+  "expected": "block",
+  "expected_error_code": "PIC_VERIFIER_FAILED",
+  "options": {
+    "strict_trust": false,
+    "verify_evidence": false,
+    "evidence_root_dir": "conformance/artifacts"
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Send payment for approved invoice",
+    "impact": "money",
+    "provenance": [
+      {
+        "id": "invoice_001",
+        "trust": "untrusted",
+        "source": "file://invoice_001.txt"
+      }
+    ],
+    "claims": [
+      {
+        "text": "Invoice #001 is approved for $500",
+        "evidence": [
+          "invoice_001"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "payments_send",
+      "args": {
+        "amount": 500
+      }
+    },
+    "evidence": [
+      {
+        "id": "invoice_001",
+        "type": "hash",
+        "ref": "file://invoice_001.txt",
+        "sha256": "a2e818612ae44f799be83833149cdd8a1ea750fa8d40bc8507f874f8ad488fbd"
+      }
+    ]
+  }
+}

--- a/conformance/trust_sanitization/financial_hash_ok__strict-f__verify-t.json
+++ b/conformance/trust_sanitization/financial_hash_ok__strict-f__verify-t.json
@@ -1,0 +1,46 @@
+{
+  "id": "trust-financial_hash_ok-strict-f-verify-t",
+  "description": "Trust-sanitization matrix cell: financial_hash_ok, strict_trust=false, verify_evidence=true. Evidence verification upgrades untrusted provenance to trusted before the verifier's contract check, allowing the money-impact proposal.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (financial_hash_ok.json, strict=F, verify=T).",
+  "mode": "trust_sanitization",
+  "expected": "allow",
+  "options": {
+    "strict_trust": false,
+    "verify_evidence": true,
+    "evidence_root_dir": "conformance/artifacts"
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Send payment for approved invoice",
+    "impact": "money",
+    "provenance": [
+      {
+        "id": "invoice_001",
+        "trust": "untrusted",
+        "source": "file://invoice_001.txt"
+      }
+    ],
+    "claims": [
+      {
+        "text": "Invoice #001 is approved for $500",
+        "evidence": [
+          "invoice_001"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "payments_send",
+      "args": {
+        "amount": 500
+      }
+    },
+    "evidence": [
+      {
+        "id": "invoice_001",
+        "type": "hash",
+        "ref": "file://invoice_001.txt",
+        "sha256": "a2e818612ae44f799be83833149cdd8a1ea750fa8d40bc8507f874f8ad488fbd"
+      }
+    ]
+  }
+}

--- a/conformance/trust_sanitization/financial_hash_ok__strict-t__verify-f.json
+++ b/conformance/trust_sanitization/financial_hash_ok__strict-t__verify-f.json
@@ -1,0 +1,47 @@
+{
+  "id": "trust-financial_hash_ok-strict-t-verify-f",
+  "description": "Trust-sanitization matrix cell: financial_hash_ok, strict_trust=true, verify_evidence=false. Provenance is already untrusted; with evidence verification disabled, no trust upgrade occurs and the money-impact proposal is rejected by the verifier.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (financial_hash_ok.json, strict=T, verify=F).",
+  "mode": "trust_sanitization",
+  "expected": "block",
+  "expected_error_code": "PIC_VERIFIER_FAILED",
+  "options": {
+    "strict_trust": true,
+    "verify_evidence": false,
+    "evidence_root_dir": "conformance/artifacts"
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Send payment for approved invoice",
+    "impact": "money",
+    "provenance": [
+      {
+        "id": "invoice_001",
+        "trust": "untrusted",
+        "source": "file://invoice_001.txt"
+      }
+    ],
+    "claims": [
+      {
+        "text": "Invoice #001 is approved for $500",
+        "evidence": [
+          "invoice_001"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "payments_send",
+      "args": {
+        "amount": 500
+      }
+    },
+    "evidence": [
+      {
+        "id": "invoice_001",
+        "type": "hash",
+        "ref": "file://invoice_001.txt",
+        "sha256": "a2e818612ae44f799be83833149cdd8a1ea750fa8d40bc8507f874f8ad488fbd"
+      }
+    ]
+  }
+}

--- a/conformance/trust_sanitization/financial_hash_ok__strict-t__verify-t.json
+++ b/conformance/trust_sanitization/financial_hash_ok__strict-t__verify-t.json
@@ -1,0 +1,46 @@
+{
+  "id": "trust-financial_hash_ok-strict-t-verify-t",
+  "description": "Trust-sanitization matrix cell: financial_hash_ok, strict_trust=true, verify_evidence=true. CANARY: evidence verification must run BEFORE the verifier's causal-contract check; the hash upgrades sanitized provenance back to trusted, allowing the money-impact proposal under strict mode. If a future refactor moves ActionProposal instantiation ahead of evidence verification, this cell flips to block.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (financial_hash_ok.json, strict=T, verify=T).",
+  "mode": "trust_sanitization",
+  "expected": "allow",
+  "options": {
+    "strict_trust": true,
+    "verify_evidence": true,
+    "evidence_root_dir": "conformance/artifacts"
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Send payment for approved invoice",
+    "impact": "money",
+    "provenance": [
+      {
+        "id": "invoice_001",
+        "trust": "untrusted",
+        "source": "file://invoice_001.txt"
+      }
+    ],
+    "claims": [
+      {
+        "text": "Invoice #001 is approved for $500",
+        "evidence": [
+          "invoice_001"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "payments_send",
+      "args": {
+        "amount": 500
+      }
+    },
+    "evidence": [
+      {
+        "id": "invoice_001",
+        "type": "hash",
+        "ref": "file://invoice_001.txt",
+        "sha256": "a2e818612ae44f799be83833149cdd8a1ea750fa8d40bc8507f874f8ad488fbd"
+      }
+    ]
+  }
+}

--- a/conformance/trust_sanitization/financial_irreversible__strict-f__verify-f.json
+++ b/conformance/trust_sanitization/financial_irreversible__strict-f__verify-f.json
@@ -1,0 +1,49 @@
+{
+  "id": "trust-financial_irreversible-strict-f-verify-f",
+  "description": "Trust-sanitization matrix cell: financial_irreversible, strict_trust=false, verify_evidence=false. Non-strict mode honors self-asserted trusted provenance; verifier allows.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (financial_irreversible.json, strict=F, verify=F).",
+  "mode": "trust_sanitization",
+  "expected": "allow",
+  "options": {
+    "strict_trust": false,
+    "verify_evidence": false
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Execute wire transfer for Q4 server costs.",
+    "impact": "money",
+    "provenance": [
+      {
+        "id": "cfo_signed_invoice_hash",
+        "trust": "trusted"
+      },
+      {
+        "id": "slack_approval_manager",
+        "trust": "untrusted"
+      }
+    ],
+    "claims": [
+      {
+        "text": "Invoice hash matches authorized payment list",
+        "evidence": [
+          "cfo_signed_invoice_hash"
+        ]
+      },
+      {
+        "text": "Manager approved the expense via Slack",
+        "evidence": [
+          "slack_approval_manager"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "treasury.wire_transfer",
+      "args": {
+        "recipient": "AWS_Global_Payments",
+        "amount": 45000,
+        "currency": "USD",
+        "reference": "INV-9901"
+      }
+    }
+  }
+}

--- a/conformance/trust_sanitization/financial_irreversible__strict-f__verify-t.json
+++ b/conformance/trust_sanitization/financial_irreversible__strict-f__verify-t.json
@@ -1,0 +1,49 @@
+{
+  "id": "trust-financial_irreversible-strict-f-verify-t",
+  "description": "Trust-sanitization matrix cell: financial_irreversible, strict_trust=false, verify_evidence=true. Non-strict mode honors self-asserted trusted provenance; verify_evidence is a no-op because the proposal carries no top-level evidence entries.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (financial_irreversible.json, strict=F, verify=T).",
+  "mode": "trust_sanitization",
+  "expected": "allow",
+  "options": {
+    "strict_trust": false,
+    "verify_evidence": true
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Execute wire transfer for Q4 server costs.",
+    "impact": "money",
+    "provenance": [
+      {
+        "id": "cfo_signed_invoice_hash",
+        "trust": "trusted"
+      },
+      {
+        "id": "slack_approval_manager",
+        "trust": "untrusted"
+      }
+    ],
+    "claims": [
+      {
+        "text": "Invoice hash matches authorized payment list",
+        "evidence": [
+          "cfo_signed_invoice_hash"
+        ]
+      },
+      {
+        "text": "Manager approved the expense via Slack",
+        "evidence": [
+          "slack_approval_manager"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "treasury.wire_transfer",
+      "args": {
+        "recipient": "AWS_Global_Payments",
+        "amount": 45000,
+        "currency": "USD",
+        "reference": "INV-9901"
+      }
+    }
+  }
+}

--- a/conformance/trust_sanitization/financial_irreversible__strict-t__verify-f.json
+++ b/conformance/trust_sanitization/financial_irreversible__strict-t__verify-f.json
@@ -1,0 +1,50 @@
+{
+  "id": "trust-financial_irreversible-strict-t-verify-f",
+  "description": "Trust-sanitization matrix cell: financial_irreversible, strict_trust=true, verify_evidence=false. Strict mode sanitizes self-asserted trusted provenance to untrusted; with evidence verification disabled, no trust upgrade occurs and the money-impact proposal is rejected by the verifier.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (financial_irreversible.json, strict=T, verify=F).",
+  "mode": "trust_sanitization",
+  "expected": "block",
+  "expected_error_code": "PIC_VERIFIER_FAILED",
+  "options": {
+    "strict_trust": true,
+    "verify_evidence": false
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Execute wire transfer for Q4 server costs.",
+    "impact": "money",
+    "provenance": [
+      {
+        "id": "cfo_signed_invoice_hash",
+        "trust": "trusted"
+      },
+      {
+        "id": "slack_approval_manager",
+        "trust": "untrusted"
+      }
+    ],
+    "claims": [
+      {
+        "text": "Invoice hash matches authorized payment list",
+        "evidence": [
+          "cfo_signed_invoice_hash"
+        ]
+      },
+      {
+        "text": "Manager approved the expense via Slack",
+        "evidence": [
+          "slack_approval_manager"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "treasury.wire_transfer",
+      "args": {
+        "recipient": "AWS_Global_Payments",
+        "amount": 45000,
+        "currency": "USD",
+        "reference": "INV-9901"
+      }
+    }
+  }
+}

--- a/conformance/trust_sanitization/financial_irreversible__strict-t__verify-t.json
+++ b/conformance/trust_sanitization/financial_irreversible__strict-t__verify-t.json
@@ -1,0 +1,50 @@
+{
+  "id": "trust-financial_irreversible-strict-t-verify-t",
+  "description": "Trust-sanitization matrix cell: financial_irreversible, strict_trust=true, verify_evidence=true. Strict mode sanitizes self-asserted trusted provenance to untrusted; verify_evidence is a no-op because the proposal carries no top-level evidence entries to upgrade with.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (financial_irreversible.json, strict=T, verify=T).",
+  "mode": "trust_sanitization",
+  "expected": "block",
+  "expected_error_code": "PIC_VERIFIER_FAILED",
+  "options": {
+    "strict_trust": true,
+    "verify_evidence": true
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Execute wire transfer for Q4 server costs.",
+    "impact": "money",
+    "provenance": [
+      {
+        "id": "cfo_signed_invoice_hash",
+        "trust": "trusted"
+      },
+      {
+        "id": "slack_approval_manager",
+        "trust": "untrusted"
+      }
+    ],
+    "claims": [
+      {
+        "text": "Invoice hash matches authorized payment list",
+        "evidence": [
+          "cfo_signed_invoice_hash"
+        ]
+      },
+      {
+        "text": "Manager approved the expense via Slack",
+        "evidence": [
+          "slack_approval_manager"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "treasury.wire_transfer",
+      "args": {
+        "recipient": "AWS_Global_Payments",
+        "amount": 45000,
+        "currency": "USD",
+        "reference": "INV-9901"
+      }
+    }
+  }
+}

--- a/conformance/trust_sanitization/privacy_risk__strict-f__verify-f.json
+++ b/conformance/trust_sanitization/privacy_risk__strict-f__verify-f.json
@@ -1,0 +1,41 @@
+{
+  "id": "trust-privacy_risk-strict-f-verify-f",
+  "description": "Trust-sanitization matrix cell: privacy_risk, strict_trust=false, verify_evidence=false. Non-strict mode honors self-asserted trusted provenance; verifier allows.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (privacy_risk.json, strict=F, verify=F).",
+  "mode": "trust_sanitization",
+  "expected": "allow",
+  "options": {
+    "strict_trust": false,
+    "verify_evidence": false
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Sync PII to Marketing Hub",
+    "impact": "privacy",
+    "provenance": [
+      {
+        "id": "user_email_consent",
+        "trust": "trusted"
+      },
+      {
+        "id": "customer_support_chat",
+        "trust": "untrusted"
+      }
+    ],
+    "claims": [
+      {
+        "text": "User provided explicit opt-in for data sync",
+        "evidence": [
+          "user_email_consent"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "hubspot.sync",
+      "args": {
+        "field": "email",
+        "value": "user@example.com"
+      }
+    }
+  }
+}

--- a/conformance/trust_sanitization/privacy_risk__strict-f__verify-t.json
+++ b/conformance/trust_sanitization/privacy_risk__strict-f__verify-t.json
@@ -1,0 +1,41 @@
+{
+  "id": "trust-privacy_risk-strict-f-verify-t",
+  "description": "Trust-sanitization matrix cell: privacy_risk, strict_trust=false, verify_evidence=true. Non-strict mode honors self-asserted trusted provenance; verify_evidence is a no-op because the proposal carries no top-level evidence entries.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (privacy_risk.json, strict=F, verify=T).",
+  "mode": "trust_sanitization",
+  "expected": "allow",
+  "options": {
+    "strict_trust": false,
+    "verify_evidence": true
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Sync PII to Marketing Hub",
+    "impact": "privacy",
+    "provenance": [
+      {
+        "id": "user_email_consent",
+        "trust": "trusted"
+      },
+      {
+        "id": "customer_support_chat",
+        "trust": "untrusted"
+      }
+    ],
+    "claims": [
+      {
+        "text": "User provided explicit opt-in for data sync",
+        "evidence": [
+          "user_email_consent"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "hubspot.sync",
+      "args": {
+        "field": "email",
+        "value": "user@example.com"
+      }
+    }
+  }
+}

--- a/conformance/trust_sanitization/privacy_risk__strict-t__verify-f.json
+++ b/conformance/trust_sanitization/privacy_risk__strict-t__verify-f.json
@@ -1,0 +1,42 @@
+{
+  "id": "trust-privacy_risk-strict-t-verify-f",
+  "description": "Trust-sanitization matrix cell: privacy_risk, strict_trust=true, verify_evidence=false. Strict mode sanitizes self-asserted trusted provenance to untrusted; with evidence verification disabled, no trust upgrade occurs and the privacy-impact proposal is rejected by the verifier.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (privacy_risk.json, strict=T, verify=F).",
+  "mode": "trust_sanitization",
+  "expected": "block",
+  "expected_error_code": "PIC_VERIFIER_FAILED",
+  "options": {
+    "strict_trust": true,
+    "verify_evidence": false
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Sync PII to Marketing Hub",
+    "impact": "privacy",
+    "provenance": [
+      {
+        "id": "user_email_consent",
+        "trust": "trusted"
+      },
+      {
+        "id": "customer_support_chat",
+        "trust": "untrusted"
+      }
+    ],
+    "claims": [
+      {
+        "text": "User provided explicit opt-in for data sync",
+        "evidence": [
+          "user_email_consent"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "hubspot.sync",
+      "args": {
+        "field": "email",
+        "value": "user@example.com"
+      }
+    }
+  }
+}

--- a/conformance/trust_sanitization/privacy_risk__strict-t__verify-t.json
+++ b/conformance/trust_sanitization/privacy_risk__strict-t__verify-t.json
@@ -1,0 +1,42 @@
+{
+  "id": "trust-privacy_risk-strict-t-verify-t",
+  "description": "Trust-sanitization matrix cell: privacy_risk, strict_trust=true, verify_evidence=true. Strict mode sanitizes self-asserted trusted provenance to untrusted; verify_evidence is a no-op because the proposal carries no top-level evidence entries to upgrade with.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (privacy_risk.json, strict=T, verify=T).",
+  "mode": "trust_sanitization",
+  "expected": "block",
+  "expected_error_code": "PIC_VERIFIER_FAILED",
+  "options": {
+    "strict_trust": true,
+    "verify_evidence": true
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Sync PII to Marketing Hub",
+    "impact": "privacy",
+    "provenance": [
+      {
+        "id": "user_email_consent",
+        "trust": "trusted"
+      },
+      {
+        "id": "customer_support_chat",
+        "trust": "untrusted"
+      }
+    ],
+    "claims": [
+      {
+        "text": "User provided explicit opt-in for data sync",
+        "evidence": [
+          "user_email_consent"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "hubspot.sync",
+      "args": {
+        "field": "email",
+        "value": "user@example.com"
+      }
+    }
+  }
+}

--- a/conformance/trust_sanitization/read_only_query__strict-f__verify-f.json
+++ b/conformance/trust_sanitization/read_only_query__strict-f__verify-f.json
@@ -1,0 +1,37 @@
+{
+  "id": "trust-read_only_query-strict-f-verify-f",
+  "description": "Trust-sanitization matrix cell: read_only_query, strict_trust=false, verify_evidence=false. Low-impact proposal is allowed regardless of trust mode.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (read_only_query.json, strict=F, verify=F).",
+  "mode": "trust_sanitization",
+  "expected": "allow",
+  "options": {
+    "strict_trust": false,
+    "verify_evidence": false
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Search internal documentation for company holiday policy.",
+    "impact": "read",
+    "provenance": [
+      {
+        "id": "user_chat_input",
+        "trust": "untrusted"
+      }
+    ],
+    "claims": [
+      {
+        "text": "User is asking for public HR policy",
+        "evidence": [
+          "user_chat_input"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "rag_engine.search",
+      "args": {
+        "query": "holiday policy 2026",
+        "collection": "hr_public"
+      }
+    }
+  }
+}

--- a/conformance/trust_sanitization/read_only_query__strict-f__verify-t.json
+++ b/conformance/trust_sanitization/read_only_query__strict-f__verify-t.json
@@ -1,0 +1,37 @@
+{
+  "id": "trust-read_only_query-strict-f-verify-t",
+  "description": "Trust-sanitization matrix cell: read_only_query, strict_trust=false, verify_evidence=true. Low-impact proposal is allowed regardless of trust mode.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (read_only_query.json, strict=F, verify=T).",
+  "mode": "trust_sanitization",
+  "expected": "allow",
+  "options": {
+    "strict_trust": false,
+    "verify_evidence": true
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Search internal documentation for company holiday policy.",
+    "impact": "read",
+    "provenance": [
+      {
+        "id": "user_chat_input",
+        "trust": "untrusted"
+      }
+    ],
+    "claims": [
+      {
+        "text": "User is asking for public HR policy",
+        "evidence": [
+          "user_chat_input"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "rag_engine.search",
+      "args": {
+        "query": "holiday policy 2026",
+        "collection": "hr_public"
+      }
+    }
+  }
+}

--- a/conformance/trust_sanitization/read_only_query__strict-t__verify-f.json
+++ b/conformance/trust_sanitization/read_only_query__strict-t__verify-f.json
@@ -1,0 +1,37 @@
+{
+  "id": "trust-read_only_query-strict-t-verify-f",
+  "description": "Trust-sanitization matrix cell: read_only_query, strict_trust=true, verify_evidence=false. Low-impact proposal is allowed regardless of trust mode.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (read_only_query.json, strict=T, verify=F).",
+  "mode": "trust_sanitization",
+  "expected": "allow",
+  "options": {
+    "strict_trust": true,
+    "verify_evidence": false
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Search internal documentation for company holiday policy.",
+    "impact": "read",
+    "provenance": [
+      {
+        "id": "user_chat_input",
+        "trust": "untrusted"
+      }
+    ],
+    "claims": [
+      {
+        "text": "User is asking for public HR policy",
+        "evidence": [
+          "user_chat_input"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "rag_engine.search",
+      "args": {
+        "query": "holiday policy 2026",
+        "collection": "hr_public"
+      }
+    }
+  }
+}

--- a/conformance/trust_sanitization/read_only_query__strict-t__verify-t.json
+++ b/conformance/trust_sanitization/read_only_query__strict-t__verify-t.json
@@ -1,0 +1,37 @@
+{
+  "id": "trust-read_only_query-strict-t-verify-t",
+  "description": "Trust-sanitization matrix cell: read_only_query, strict_trust=true, verify_evidence=true. Low-impact proposal is allowed regardless of trust mode.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (read_only_query.json, strict=T, verify=T).",
+  "mode": "trust_sanitization",
+  "expected": "allow",
+  "options": {
+    "strict_trust": true,
+    "verify_evidence": true
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Search internal documentation for company holiday policy.",
+    "impact": "read",
+    "provenance": [
+      {
+        "id": "user_chat_input",
+        "trust": "untrusted"
+      }
+    ],
+    "claims": [
+      {
+        "text": "User is asking for public HR policy",
+        "evidence": [
+          "user_chat_input"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "rag_engine.search",
+      "args": {
+        "query": "holiday policy 2026",
+        "collection": "hr_public"
+      }
+    }
+  }
+}

--- a/conformance/trust_sanitization/robotic_action__strict-f__verify-f.json
+++ b/conformance/trust_sanitization/robotic_action__strict-f__verify-f.json
@@ -1,0 +1,47 @@
+{
+  "id": "trust-robotic_action-strict-f-verify-f",
+  "description": "Trust-sanitization matrix cell: robotic_action, strict_trust=false, verify_evidence=false. Non-strict mode honors self-asserted trusted provenance; verifier allows.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (robotic_action.json, strict=F, verify=F).",
+  "mode": "trust_sanitization",
+  "expected": "allow",
+  "options": {
+    "strict_trust": false,
+    "verify_evidence": false
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Initialize emergency shutdown of industrial arm.",
+    "impact": "irreversible",
+    "provenance": [
+      {
+        "id": "lidar_safety_trigger",
+        "trust": "trusted"
+      },
+      {
+        "id": "operator_voice_command",
+        "trust": "untrusted"
+      }
+    ],
+    "claims": [
+      {
+        "text": "LIDAR detected obstacle within 0.5m hazard zone",
+        "evidence": [
+          "lidar_safety_trigger"
+        ]
+      },
+      {
+        "text": "Operator shouted 'Emergency Stop'",
+        "evidence": [
+          "operator_voice_command"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "abb_arm.halt",
+      "args": {
+        "mode": "hard_stop",
+        "engage_brakes": true
+      }
+    }
+  }
+}

--- a/conformance/trust_sanitization/robotic_action__strict-f__verify-t.json
+++ b/conformance/trust_sanitization/robotic_action__strict-f__verify-t.json
@@ -1,0 +1,47 @@
+{
+  "id": "trust-robotic_action-strict-f-verify-t",
+  "description": "Trust-sanitization matrix cell: robotic_action, strict_trust=false, verify_evidence=true. Non-strict mode honors self-asserted trusted provenance; verify_evidence is a no-op because the proposal carries no top-level evidence entries.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (robotic_action.json, strict=F, verify=T).",
+  "mode": "trust_sanitization",
+  "expected": "allow",
+  "options": {
+    "strict_trust": false,
+    "verify_evidence": true
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Initialize emergency shutdown of industrial arm.",
+    "impact": "irreversible",
+    "provenance": [
+      {
+        "id": "lidar_safety_trigger",
+        "trust": "trusted"
+      },
+      {
+        "id": "operator_voice_command",
+        "trust": "untrusted"
+      }
+    ],
+    "claims": [
+      {
+        "text": "LIDAR detected obstacle within 0.5m hazard zone",
+        "evidence": [
+          "lidar_safety_trigger"
+        ]
+      },
+      {
+        "text": "Operator shouted 'Emergency Stop'",
+        "evidence": [
+          "operator_voice_command"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "abb_arm.halt",
+      "args": {
+        "mode": "hard_stop",
+        "engage_brakes": true
+      }
+    }
+  }
+}

--- a/conformance/trust_sanitization/robotic_action__strict-t__verify-f.json
+++ b/conformance/trust_sanitization/robotic_action__strict-t__verify-f.json
@@ -1,0 +1,48 @@
+{
+  "id": "trust-robotic_action-strict-t-verify-f",
+  "description": "Trust-sanitization matrix cell: robotic_action, strict_trust=true, verify_evidence=false. Strict mode sanitizes self-asserted trusted provenance to untrusted; with evidence verification disabled, no trust upgrade occurs and the irreversible-impact proposal is rejected by the verifier.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (robotic_action.json, strict=T, verify=F).",
+  "mode": "trust_sanitization",
+  "expected": "block",
+  "expected_error_code": "PIC_VERIFIER_FAILED",
+  "options": {
+    "strict_trust": true,
+    "verify_evidence": false
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Initialize emergency shutdown of industrial arm.",
+    "impact": "irreversible",
+    "provenance": [
+      {
+        "id": "lidar_safety_trigger",
+        "trust": "trusted"
+      },
+      {
+        "id": "operator_voice_command",
+        "trust": "untrusted"
+      }
+    ],
+    "claims": [
+      {
+        "text": "LIDAR detected obstacle within 0.5m hazard zone",
+        "evidence": [
+          "lidar_safety_trigger"
+        ]
+      },
+      {
+        "text": "Operator shouted 'Emergency Stop'",
+        "evidence": [
+          "operator_voice_command"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "abb_arm.halt",
+      "args": {
+        "mode": "hard_stop",
+        "engage_brakes": true
+      }
+    }
+  }
+}

--- a/conformance/trust_sanitization/robotic_action__strict-t__verify-t.json
+++ b/conformance/trust_sanitization/robotic_action__strict-t__verify-t.json
@@ -1,0 +1,48 @@
+{
+  "id": "trust-robotic_action-strict-t-verify-t",
+  "description": "Trust-sanitization matrix cell: robotic_action, strict_trust=true, verify_evidence=true. Strict mode sanitizes self-asserted trusted provenance to untrusted; verify_evidence is a no-op because the proposal carries no top-level evidence entries to upgrade with.",
+  "source": "Lifted from tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX (robotic_action.json, strict=T, verify=T).",
+  "mode": "trust_sanitization",
+  "expected": "block",
+  "expected_error_code": "PIC_VERIFIER_FAILED",
+  "options": {
+    "strict_trust": true,
+    "verify_evidence": true
+  },
+  "proposal": {
+    "protocol": "PIC/1.0",
+    "intent": "Initialize emergency shutdown of industrial arm.",
+    "impact": "irreversible",
+    "provenance": [
+      {
+        "id": "lidar_safety_trigger",
+        "trust": "trusted"
+      },
+      {
+        "id": "operator_voice_command",
+        "trust": "untrusted"
+      }
+    ],
+    "claims": [
+      {
+        "text": "LIDAR detected obstacle within 0.5m hazard zone",
+        "evidence": [
+          "lidar_safety_trigger"
+        ]
+      },
+      {
+        "text": "Operator shouted 'Emergency Stop'",
+        "evidence": [
+          "operator_voice_command"
+        ]
+      }
+    ],
+    "action": {
+      "tool": "abb_arm.halt",
+      "args": {
+        "mode": "hard_stop",
+        "engage_brakes": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Second PR of the v0.8.2 conformance campaign. Adds the **trust-sanitization** conformance mode and 24 vectors that codify the v0.7.5 Trust Axiom + `strict_trust=True` behavior as portable, runner-verifiable assertions.

Each vector is one cell of the 2-D matrix `proposal_base x strict_trust x verify_evidence`. Lifted 1:1 from the in-tree `VERDICT_REGRESSION_MATRIX` in `tests/test_trust_deprecation_warning.py` so that portable vectors and the Python regression test agree row-for-row. Any divergence is a merge-blocker by construction.

Implements ROADMAP §1.2 (trust-sanitization portable vectors) per the v0.8.2 plan PR V8.2-2.

## Matrix shape

6 proposal bases x 2 strict_trust x 2 verify_evidence = **24 vectors total**.

| `matrix_id` | impact | provenance shape | FF | FT | TF | TT |
|---|---|---|---|---|---|---|
| `compute_risk` | compute | self-asserted trusted + untrusted | allow | allow | allow | allow |
| `read_only_query` | read_only | all untrusted | allow | allow | allow | allow |
| `financial_hash_ok` | money | one untrusted, hash-evidence-backed | block | allow | block | allow |
| `financial_irreversible` | money | self-asserted trusted + untrusted, no evidence | allow | allow | block | block |
| `privacy_risk` | privacy | self-asserted trusted + untrusted, no evidence | allow | allow | block | block |
| `robotic_action` | irreversible | self-asserted trusted + untrusted, no evidence | allow | allow | block | block |

Verdict cells (FF / FT / TF / TT = `strict-f-verify-f` / `strict-f-verify-t` / `strict-t-verify-f` / `strict-t-verify-t`):

- **Low-impact (`compute_risk`, `read_only_query`)**: verifier allows under all four settings (no impact gate to fail).
- **Money + evidence-backed (`financial_hash_ok`)**: behavior pivots on `verify_evidence` only — hash-evidence upgrades the untrusted provenance to trusted when verification runs (CANARY: the strict-t-verify-t cell would flip to `block` if a future refactor moved `ActionProposal` construction ahead of evidence verification).
- **Self-asserted-trusted high-impact (`financial_irreversible`, `privacy_risk`, `robotic_action`)**: identical shape — `strict=false` honors the self-assertion, `strict=true` sanitizes to untrusted and the proposal carries no top-level evidence to upgrade back, so both strict-true cells reject with `PIC_VERIFIER_FAILED`.

All 6 `block` cells use `expected_error_code: "PIC_VERIFIER_FAILED"`. The runner enforces this — see "Runner contract" below.

## What's in this PR (per commit)

| Commit | Scope |
|---|---|
| `fcf6517d` — runner mode + canary | New `_run_trust_sanitization_vector()` dispatch arm in `conformance/run.py` (~280 LOC of defensive guards), `TRUST_SANITIZATION_MATRIX_IDS` whitelist, `conformance/trust_sanitization/README.md` contract documentation, 1 canary vector (`compute_risk__strict-f__verify-f.json`) to validate the runner end-to-end |
| `9b6011bd` — low-impact bases | 7 vectors completing `compute_risk` (3 remaining cells) and `read_only_query` (all 4 cells) — both bases allow under all four matrix settings |
| `ed054a56` — financial_hash_ok | 4 vectors covering the evidence-backed money base; CANARY cell `strict-t-verify-t` proves evidence verification runs BEFORE the verifier's causal-contract check |
| `7a7204e2` — strict-trust matrix | 12 vectors completing `financial_irreversible`, `privacy_risk`, `robotic_action`; the strict-true rows are the Trust Axiom proof points |

Total: 27 files changed, +1809 / -28.

## Runner contract (defensive guards in `_run_trust_sanitization_vector`)

The new dispatch arm is deliberately strict so that vector authors can't accidentally write a vector that silently passes for the wrong reason. Each guard exists to close a specific failure mode:

| Guard | Why |
|---|---|
| `matrix_id` MUST be in `TRUST_SANITIZATION_MATRIX_IDS` whitelist (the 6 bases) | Prevents drift between vector authors and the regression matrix; new bases require an explicit runner update |
| `expected_error_code` on `block` cells MUST equal `PIC_VERIFIER_FAILED` | The whole point of these vectors is the verifier's causal-contract rejection; any other code means the test is exercising the wrong path |
| Vector filename MUST be derivable from `matrix_id` + `(strict_trust, verify_evidence)` booleans | Coordinate consistency — manifest entry, file path, vector `id`, and inline options can't disagree |
| `options.strict_trust` and `options.verify_evidence` MUST be present and JSON booleans | Refuses to silently use defaults; the matrix coordinate is part of the contract |
| `embedded_keyring` MUST NOT appear in trust_sanitization vectors | The mode does not bind a keyring resolver into `PipelineOptions`; a declared keyring would be silently ignored and mislead reviewers |
| Sig evidence in the proposal MUST be rejected | Same reason — no keyring is bound, so sig verification would fall back to `PIC_KEYS_PATH` (env-var hole that evidence mode explicitly closes). Authors who need sig coverage use evidence mode |
| `options.key_resolver` and `options.proposal_base_dir` MUST NOT be vector-declared | Runner-controlled fields, same portability principle as evidence mode |
| File-backed hash evidence MUST declare non-empty `options.evidence_root_dir` | Reuses the evidence-mode helper to resolve the root against the repository root and reject paths escaping `conformance/artifacts/` |

A vector that trips any guard fails with a clear `reason` rather than silently producing a misleading PASS.

## Source-of-truth reconciliation

The vectors are not a re-derivation. Each `(matrix_id, strict_trust, verify_evidence) -> (expected, expected_error_code)` row is lifted verbatim from `tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX` (the 24-row in-tree regression test that pre-dates this PR).

Reconciliation discipline:
- Each vector file's `source` field cites the matrix row it was lifted from.
- The 6 `matrix_id` bases here are the 6 bases in the regression matrix — no new bases invented, no existing bases dropped.
- The `block` verdict + `PIC_VERIFIER_FAILED` code on every strict-true high-impact cell match the regression matrix's enum value.

If a v0.9.0 refactor changes the regression matrix, the portable vectors here will diverge and the conformance run will catch it before merge. Likewise if a future contributor edits a vector without updating the regression matrix.

## Out of scope (deferred to later v0.8.2 PRs)

- Runner CLI hardening (`--json`, `--filter-mode`, `--filter-id`) — PR V8.2-3
- DRAFT `docs/spec-core.md` + `docs/spec-evidence.md` — PR V8.2-4
- Opt-in canonical attestation-object signing — PR V8.2-5
- Changes to `pipeline.py` / `verifier.py` — none needed; the existing `strict_trust` x `verify_evidence` implementation already covers all 24 cells. This PR is pure portable codification.
- Changes to `tests/test_trust_deprecation_warning.py` regression matrix — the matrix is source-of-truth here; bug-fixing it is a separate task.

## Test plan

- [x] `python -m conformance.run` → `Summary: 51/51 passed` (13 prior + 14 evidence + 12 prior trust + 12 new trust)
- [x] `ruff check conformance/run.py` → `All checks passed!`
- [x] `ruff format --check conformance/run.py` → `1 file already formatted`
- [x] Every new vector PASSes; defensive guards stay silent (no trip-wires fired during legitimate runs)
- [x] All 6 `block` cells exit with `PIC_VERIFIER_FAILED` (matrix_id-enforced)
- [x] CI green on `feat/v0.8.2-trust-sanitization-vectors` before squash-merge

## Reviewer guidance

- **Per-commit review is the cheap path.** The 4 commits are deliberately ordered runner-first then vectors-by-group. Reviewing in order is `runner contract -> canary -> low-impact bases -> evidence-backed base -> strict-trust matrix`.
- **Cross-check sample**: pick any vector at random, find the corresponding row in `tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX`, confirm `(expected, expected_error_code)` agree.
- **Verbose JSON style is intentional** (one element per line) to match V8.2-1 evidence vectors and keep review diffs readable.
- The CANARY note on `financial_hash_ok__strict-t__verify-t.json`'s description explains a load-bearing ordering invariant — worth understanding before approving.
