### PR TITLE
feat(conformance): runner hardening — --json / filters / taxonomy / test suite (v0.8.2 PR 3)

### DIFF
--- a/conformance/run.py
+++ b/conformance/run.py
@@ -16,6 +16,7 @@ From the repo root::
     python -m conformance.run
     python -m conformance.run --manifest conformance/manifest.json
     python -m conformance.run --verbose
+    python -m conformance.run --json
 
 Exit codes
 ----------
@@ -220,35 +221,40 @@ class ManifestError(Exception):
 # HumanRenderer.render_report; RunnerReport.format_summary is kept as a
 # delegating compatibility shim).
 #
-# ManifestError handling intentionally stays out of the renderer surface in
-# commit 1. main() retains its existing
-#     except ManifestError as e:
-#         print(f"ManifestError: {e}", file=sys.stderr)
-#         return 2
-# contract from v0.8.2 PR V8.2-2. Routing manifest-error envelopes through
-# the renderer lands in commit 2 alongside the --json output mode, when the
-# JSON manifest-error envelope shape defined in the PR V8.2-3 design
-# checkpoint §2 needs a structured rendering path.
+# Commit 2 (this commit) adds JsonRenderer for --json output mode and
+# extends the Renderer protocol with render_manifest_error so both
+# renderer implementations can surface manifest-load failures through
+# their declared output format. main() chooses the renderer and routes
+# both the success path (render_report) and the ManifestError path
+# (render_manifest_error) through it. Human mode keeps writing
+# ManifestError to stderr; JSON mode writes the manifest-error envelope
+# from PR V8.2-3 design checkpoint section 2 to stdout (JSON consumers
+# parse a single stream).
+#
+# Commit 3 will add --filter-mode / --filter-id flags, the 8-token
+# diagnostic taxonomy, summary.diagnostic="no_vectors_selected" handling,
+# and populate results[].reason_code (which commit 2 leaves null for
+# both passing and failing vectors per the staged-refactor lock).
 
 
 class Renderer(Protocol):
     """Output renderer protocol for the conformance runner.
 
-    Implementations transform a :class:`RunnerReport` into a string that
-    :func:`main` writes to stdout. The renderer abstraction is the seam
-    on which the v0.8.2 PR V8.2-3 follow-up commits build:
+    Implementations transform a :class:`RunnerReport` (or a manifest
+    error message) into a string that :func:`main` writes to stdout
+    (or stderr for human-mode manifest errors). The renderer
+    abstraction is the seam on which the v0.8.2 PR V8.2-3 follow-up
+    commits build:
 
-      - Commit 2: ``JsonRenderer`` emits the JSON document defined in the
-        design checkpoint §2 (including the explicit manifest-error
-        envelope; commit 2 also routes ``ManifestError`` through this
-        renderer rather than the bare stderr print).
-      - Commit 3: filter-aware selection plumbing + the 8-token diagnostic
-        taxonomy are added; the renderer signature grows to accept the
-        selection block so JSON output's ``selection.filter_modes`` /
-        ``selection.filter_ids`` fields can be populated.
-
-    Commit 1 keeps the surface minimal: one method, one parameter beyond
-    the report itself.
+      - Commit 2 (this commit): ``JsonRenderer`` emits the JSON document
+        defined in the design checkpoint section 2, including the
+        explicit manifest-error envelope.
+      - Commit 3: filter-aware selection plumbing + the 8-token
+        diagnostic taxonomy are added; the renderer signature grows to
+        accept the selection block so JSON output's
+        ``selection.filter_modes`` / ``selection.filter_ids`` fields
+        can be populated, and ``results[].reason_code`` becomes non-null
+        for failing vectors.
     """
 
     def render_report(self, report: RunnerReport, *, verbose: bool) -> str:
@@ -257,6 +263,27 @@ class Renderer(Protocol):
         The returned string does NOT include a trailing newline; the
         caller's ``print()`` supplies it. Matches the v0.8.2 PR V8.2-2
         ``RunnerReport.format_summary()`` contract.
+        """
+        ...
+
+    def render_manifest_error(
+        self,
+        message: str,
+        *,
+        manifest_version: Optional[str] = None,
+    ) -> str:
+        """Render a manifest-error envelope/message.
+
+        Implementations decide the format: :class:`HumanRenderer`
+        returns the freeform ``"ManifestError: <message>"`` string that
+        v0.8.2 PR V8.2-2 wrote to stderr; :class:`JsonRenderer` returns
+        the JSON manifest-error envelope from PR V8.2-3 design
+        checkpoint section 2.
+
+        ``manifest_version`` is populated by the caller iff it was
+        readable before the validation failure point. The human form
+        ignores it; the JSON form surfaces it as ``manifest_version``
+        (else ``null``).
         """
         ...
 
@@ -278,8 +305,13 @@ class HumanRenderer:
       - Final ``Summary: X/Y passed`` line; suffix ``(Z failed)`` when
         not all vectors passed.
 
-    The byte-equivalence claim is verified at commit 1 save time by
-    SHA256-comparing pre-save and post-save default-invocation stdout.
+    Manifest-error form (added in commit 2) returns the byte-identical
+    ``"ManifestError: <message>"`` string that v0.8.2 PR V8.2-2 wrote to
+    stderr; :func:`main` continues to send it to stderr in human mode.
+
+    The byte-equivalence claim is verified at each PR V8.2-3 commit save
+    time by SHA256-comparing pre-save and post-save default-invocation
+    stdout.
     """
 
     def render_report(self, report: RunnerReport, *, verbose: bool) -> str:
@@ -304,6 +336,141 @@ class HumanRenderer:
                 f"Summary: {report.passed_count}/{report.total_count} passed ({failed} failed)"
             )
         return "\n".join(lines)
+
+    def render_manifest_error(
+        self,
+        message: str,
+        *,
+        manifest_version: Optional[str] = None,
+    ) -> str:
+        """Render a manifest-error message in human-readable form.
+
+        Output is byte-identical to the v0.8.2 PR V8.2-2 stderr message
+        ``"ManifestError: <message>"``. The ``manifest_version``
+        parameter is accepted for protocol parity with
+        :class:`JsonRenderer` but intentionally not surfaced — the human
+        form has nowhere to expose it without breaking the
+        byte-identical guarantee.
+        """
+        del manifest_version
+        return f"ManifestError: {message}"
+
+
+class JsonRenderer:
+    """JSON output renderer for the conformance runner.
+
+    Emits the JSON document defined in v0.8.2 PR V8.2-3 design checkpoint
+    section 2. Output is pretty-printed (2-space indent) to stdout. The
+    renderer is the sole producer of output when ``--json`` is set;
+    ``--verbose`` is accepted but has no effect (JSON always carries
+    full per-vector detail).
+
+    Commit-staged contract notes (refined in subsequent PR V8.2-3 commits):
+
+      - In commit 2 (this commit), ``results[].reason_code`` is ``null``
+        for both passing AND failing vectors; the 8-token diagnostic
+        taxonomy populates the field in commit 3. The freeform
+        ``results[].message`` field carries the existing failure-reason
+        string verbatim in the meantime, so debuggability is preserved
+        across the staged refactor.
+      - In commit 2, ``summary.diagnostic`` and ``summary.message`` are
+        ``null`` for normal-run reports. They become non-null in commit
+        3 when ``--filter-*`` selects zero vectors (diagnostic
+        ``"no_vectors_selected"``). The manifest-error envelope path
+        uses ``summary.diagnostic="manifest_invalid"`` already in this
+        commit (see :meth:`render_manifest_error`).
+      - ``selection.filter_modes`` / ``selection.filter_ids`` are always
+        empty lists in commit 2 (no filter flags exist yet); commit 3
+        populates them.
+
+    Manifest-error envelope ``summary.message`` is rendered as
+    ``"ManifestError: <message>"`` — the same prefix
+    :class:`HumanRenderer` uses for stderr. The prefix is part of the
+    locked PR V8.2-3 design checkpoint section 2 shape so JSON consumers
+    and humans see the same error string format.
+    """
+
+    def render_report(self, report: RunnerReport, *, verbose: bool) -> str:
+        # verbose is accepted for Renderer protocol parity but ignored:
+        # JSON output always carries full per-vector detail.
+        del verbose
+        results_json: List[Dict[str, Any]] = []
+        for r in report.results:
+            results_json.append(
+                {
+                    "id": r.id,
+                    "mode": r.mode,
+                    "passed": r.passed,
+                    # reason_code is None in commit 2 for both passing and
+                    # failing vectors; commit 3 populates with the 8-token
+                    # diagnostic taxonomy. Freeform `message` carries the
+                    # legacy reason string verbatim so failing-vector
+                    # diagnostics remain visible during the staged refactor.
+                    "reason_code": None,
+                    "message": r.reason if (not r.passed and r.reason) else None,
+                }
+            )
+        envelope: Dict[str, Any] = {
+            "manifest_version": report.manifest_version,
+            "selection": {
+                "total_in_manifest": report.total_count,
+                "selected": report.total_count,
+                "filter_modes": [],
+                "filter_ids": [],
+            },
+            "results": results_json,
+            "summary": {
+                "total": report.total_count,
+                "passed": report.passed_count,
+                "failed": report.total_count - report.passed_count,
+                "all_passed": report.all_passed,
+                "diagnostic": None,
+                "message": None,
+            },
+            "exit_code": 0 if report.all_passed else 1,
+        }
+        return json.dumps(envelope, indent=2)
+
+    def render_manifest_error(
+        self,
+        message: str,
+        *,
+        manifest_version: Optional[str] = None,
+    ) -> str:
+        """Render the JSON manifest-error envelope per design checkpoint section 2.
+
+        ``manifest_version`` may be populated if the manifest's top-level
+        ``version`` field was readable before the validation failure
+        point; otherwise ``None``. In commit 2 the runner always passes
+        ``None`` (no fine-grained "we got past version parsing" signal
+        from :func:`_validate_manifest`); commit 3 may refine if the
+        differentiation becomes useful for operators.
+
+        ``summary.message`` is rendered with the ``"ManifestError: "``
+        prefix — same as the :class:`HumanRenderer` stderr form — per
+        the PR V8.2-3 design checkpoint section 2 lock. JSON consumers
+        and humans observe the same error string format.
+        """
+        envelope: Dict[str, Any] = {
+            "manifest_version": manifest_version,
+            "selection": {
+                "total_in_manifest": 0,
+                "selected": 0,
+                "filter_modes": [],
+                "filter_ids": [],
+            },
+            "results": [],
+            "summary": {
+                "total": 0,
+                "passed": 0,
+                "failed": 0,
+                "all_passed": False,
+                "diagnostic": "manifest_invalid",
+                "message": f"ManifestError: {message}",
+            },
+            "exit_code": 2,
+        }
+        return json.dumps(envelope, indent=2)
 
 
 # ---------------------------------------------------------------------------
@@ -1365,22 +1532,36 @@ def main(argv: Optional[List[str]] = None) -> int:
         "--verbose",
         "-v",
         action="store_true",
-        help="Show per-vector detail even for passing vectors.",
+        help="Show per-vector detail even for passing vectors (human mode only).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help=(
+            "Emit machine-readable JSON output to stdout instead of human "
+            "text. Suppresses all human prose; the manifest-error envelope "
+            "goes to stdout (not stderr) so JSON consumers can parse a "
+            "single stream."
+        ),
     )
     args = parser.parse_args(argv)
+
+    renderer: Renderer = JsonRenderer() if args.json else HumanRenderer()
 
     try:
         report = run_manifest(Path(args.manifest))
     except ManifestError as e:
-        # ManifestError handling stays out of the renderer surface in commit
-        # 1 (PR V8.2-3). Commit 2 will route this through the renderer when
-        # the JSON manifest-error envelope shape from the design checkpoint
-        # §2 lands. The stderr-print + exit-2 contract preserves v0.8.2 PR
-        # V8.2-2 behavior byte-for-byte.
-        print(f"ManifestError: {e}", file=sys.stderr)
+        # Human mode: print to stderr (byte-identical to v0.8.2 PR V8.2-2).
+        # JSON mode:  print the manifest-error envelope to stdout per the
+        # PR V8.2-3 design checkpoint section 2 lock — JSON consumers MUST
+        # be able to parse a single stream without merging stderr.
+        rendered = renderer.render_manifest_error(str(e))
+        if args.json:
+            print(rendered)
+        else:
+            print(rendered, file=sys.stderr)
         return 2
 
-    renderer: Renderer = HumanRenderer()
     print(renderer.render_report(report, verbose=args.verbose))
     return 0 if report.all_passed else 1
 

--- a/conformance/run.py
+++ b/conformance/run.py
@@ -17,13 +17,25 @@ From the repo root::
     python -m conformance.run --manifest conformance/manifest.json
     python -m conformance.run --verbose
     python -m conformance.run --json
+    python -m conformance.run --filter-mode evidence
+    python -m conformance.run --filter-id canon-001-basic-object
 
 Exit codes
 ----------
-- 0  — all vectors passed.
-- 1  — at least one vector failed (manifest itself was valid).
-- 2  — manifest was malformed (unknown field, invalid mode/expected
-       combination, duplicate id, missing required field, etc.).
+- 0  — all selected vectors passed (or empty manifest with no filter
+       applied; see ``RunnerReport.all_passed``).
+- 1  — at least one selected vector failed (manifest itself was valid).
+- 2  — manifest was malformed, OR an explicit filter selected zero vectors.
+
+Diagnostic taxonomy
+-------------------
+Per-vector failures and summary-level outcomes are tagged with one of the
+eight tokens defined in the ``DC_*`` constants below (v0.8.2 PR V8.2-3
+design checkpoint §3). ``--json`` output surfaces the per-vector token in
+``results[].reason_code`` and the summary token in
+``summary.diagnostic``. Human mode preserves the existing freeform
+per-vector reason text and surfaces summary diagnostics such as
+``no_vectors_selected`` in the diagnostic block.
 
 Schema validation
 -----------------
@@ -51,6 +63,18 @@ coordinate consistency: the vector ``id`` and manifest ``file`` MUST match
 the expected forms derived from ``matrix_id`` + the boolean coordinates in
 ``options``. This prevents silent matrix corruption (a file named for one
 cell but containing the options of another).
+
+Filtering
+---------
+``--filter-mode <mode>`` (repeatable) and ``--filter-id <id>`` (repeatable)
+select a subset of manifest entries to execute. Multiple flags of the same
+kind UNION together, and the two kinds also union with each other — a
+vector is selected if it matches ANY mode filter OR ANY id filter. When
+neither flag is present, all vectors are selected. Unknown filter values
+(unknown mode names, unknown ids) are not validated at argparse time;
+they simply select nothing. An explicit filter that selects zero vectors
+triggers ``summary.diagnostic="no_vectors_selected"`` and exit 2 — silent
+CI passes on typo'd filter targets would be dangerous.
 
 Warning handling
 ----------------
@@ -148,26 +172,135 @@ ENTRY_FIELDS: Dict[tuple, set] = {
 
 
 # ---------------------------------------------------------------------------
+# Diagnostic taxonomy (v0.8.2 PR V8.2-3 commit 3, design checkpoint §3)
+# ---------------------------------------------------------------------------
+#
+# The eight-token taxonomy is the stable surface that machine consumers
+# (CI gates, dashboards, the v0.9.0 TS verifier's parity tests) match on.
+# Freeform per-result detail lives in ``VectorResult.reason`` (carried
+# into JSON output's ``results[].message``); the category lives in
+# ``VectorResult.reason_code`` (carried into ``results[].reason_code``).
+# Splitting code from prose keeps the contract small while preserving
+# debuggability.
+#
+# Six tokens are per-result. Two tokens are summary-only.
+#
+# Per-result tokens (VectorResult.reason_code):
+
+# Verifier returned allow/block different from the vector's ``expected``.
+DC_VERDICT_MISMATCH = "verdict_mismatch"
+
+# Block verdict happened, but error code differed from ``expected_error_code``.
+DC_ERROR_CODE_MISMATCH = "error_code_mismatch"
+
+# Canonical bytes or canonical SHA-256 mismatch on a canonicalization vector.
+DC_CANONICALIZATION_MISMATCH = "canonicalization_mismatch"
+
+# Manifest valid but points at wrong/missing vector file, or vector inline
+# id/mode/expected/expected_error_code/coordinate disagrees with the
+# manifest entry. NOT for malformed manifest JSON — that is
+# ``DC_MANIFEST_INVALID`` (summary-only).
+DC_MANIFEST_DRIFT = "manifest_drift"
+
+# Vector file exists and parses but violates a runner/vector guard shape:
+# missing options, wrong option types, forbidden ``embedded_keyring`` in
+# trust_sanitization mode, sig evidence in trust_sanitization mode, bad
+# ``evidence_root_dir``, ``PipelineOptions(**options)`` construction
+# failure, etc. Authoring/shape errors at the vector level.
+DC_VECTOR_INVALID = "vector_invalid"
+
+# Unexpected exception caught at the dispatch boundary (``canonicalize()``
+# or ``verify_proposal()`` raised). Genuine "this should not normally
+# happen" bucket; narrow in practice after commit 3 re-categorized
+# ``PipelineOptions`` construction failures to ``DC_VECTOR_INVALID``.
+DC_RUNNER_ERROR = "runner_error"
+
+# Summary-only tokens (RunnerReport.diagnostic / JSON summary.diagnostic):
+
+# Explicit --filter-mode / --filter-id selected zero vectors. Surfaces as
+# ``summary.diagnostic`` + exit 2.
+DC_NO_VECTORS_SELECTED = "no_vectors_selected"
+
+# Manifest parse / top-level schema / entry validation failed before any
+# vectors could be selected or executed. Surfaces via
+# ``JsonRenderer.render_manifest_error`` (commit 2) — the
+# ``ManifestError`` exception short-circuits before a ``RunnerReport`` is
+# built, so this token never appears on a ``RunnerReport.diagnostic``
+# field, only on the manifest-error JSON envelope.
+DC_MANIFEST_INVALID = "manifest_invalid"
+
+
+# ---------------------------------------------------------------------------
 # Result types
 # ---------------------------------------------------------------------------
 
 
 @dataclass
+class Selection:
+    """Filter state + manifest size, populated by :func:`run_manifest`.
+
+    ``total_in_manifest`` reflects the full manifest (pre-filter) count;
+    ``selected`` is the count after filter application. Empty
+    ``filter_modes`` AND empty ``filter_ids`` means "no filter applied" —
+    in that case ``selected == total_in_manifest``.
+    """
+
+    total_in_manifest: int
+    selected: int
+    filter_modes: List[str] = field(default_factory=list)
+    filter_ids: List[str] = field(default_factory=list)
+
+
+@dataclass
 class VectorResult:
-    """Outcome of running a single manifest vector."""
+    """Outcome of running a single manifest vector.
+
+    ``reason_code`` is populated for failing vectors from the 8-token
+    diagnostic taxonomy (``DC_*`` constants). Passing vectors leave
+    ``reason_code`` as ``None`` (the contract: ``reason_code is None
+    iff passed``). The freeform ``reason`` carries the human-readable
+    detail that surfaces in JSON output's ``results[].message`` field
+    and in indented human-mode failure output.
+    """
 
     id: str
     mode: str
     passed: bool
     reason: str = ""
+    reason_code: Optional[str] = None
 
 
 @dataclass
 class RunnerReport:
-    """Aggregate outcome of running a manifest."""
+    """Aggregate outcome of running a manifest.
+
+    Additions in v0.8.2 PR V8.2-3 commit 3:
+
+      - ``selection``: filter state + manifest size, populated by
+        :func:`run_manifest`. Default-constructed value is
+        ``Selection(total_in_manifest=0, selected=0)`` so external
+        callers building a RunnerReport by hand don't have to know
+        about the new field.
+      - ``diagnostic`` / ``message``: summary-level diagnostic token +
+        freeform detail. Currently only set to
+        ``DC_NO_VECTORS_SELECTED`` when filters select zero vectors.
+        Manifest-level errors flow through :exc:`ManifestError` and
+        never reach this field; ``DC_MANIFEST_INVALID`` lives on the
+        JSON manifest-error envelope.
+      - ``failed_count`` / ``exit_code`` properties: single sources of
+        truth that both renderers and ``main()`` consume.
+      - ``all_passed`` lock changed (design checkpoint §5): now
+        ``failed_count == 0 AND diagnostic is None``. Empty manifest
+        with no filter applied → ``all_passed=True``, ``exit_code=0``
+        (vacuous success). Previously ``all_passed`` was
+        ``total_count > 0 AND passed == total``.
+    """
 
     manifest_version: str
     results: List[VectorResult] = field(default_factory=list)
+    selection: Selection = field(default_factory=lambda: Selection(0, 0))
+    diagnostic: Optional[str] = None
+    message: Optional[str] = None
 
     @property
     def passed_count(self) -> int:
@@ -178,8 +311,33 @@ class RunnerReport:
         return len(self.results)
 
     @property
+    def failed_count(self) -> int:
+        return self.total_count - self.passed_count
+
+    @property
     def all_passed(self) -> bool:
-        return self.total_count > 0 and self.passed_count == self.total_count
+        return self.failed_count == 0 and self.diagnostic is None
+
+    @property
+    def exit_code(self) -> int:
+        """Process exit code, derived from report state.
+
+        Single source of truth: ``JsonRenderer`` puts this in the
+        envelope's ``exit_code`` field, ``main()`` returns it. Per
+        design checkpoint §5:
+
+          - ``diagnostic == "no_vectors_selected"`` → 2
+          - ``diagnostic == "manifest_invalid"``    → 2 (defensive;
+            this case actually flows through ``ManifestError`` and
+            never reaches a RunnerReport instance, but the mapping is
+            included for completeness in case future code paths
+            populate the field)
+          - ``failed_count > 0``                    → 1
+          - otherwise                                → 0
+        """
+        if self.diagnostic in (DC_NO_VECTORS_SELECTED, DC_MANIFEST_INVALID):
+            return 2
+        return 0 if self.failed_count == 0 else 1
 
     def format_summary(self, verbose: bool = False) -> str:
         """Back-compat shim that delegates to :class:`HumanRenderer`.
@@ -221,40 +379,49 @@ class ManifestError(Exception):
 # HumanRenderer.render_report; RunnerReport.format_summary is kept as a
 # delegating compatibility shim).
 #
-# Commit 2 (this commit) adds JsonRenderer for --json output mode and
-# extends the Renderer protocol with render_manifest_error so both
-# renderer implementations can surface manifest-load failures through
-# their declared output format. main() chooses the renderer and routes
-# both the success path (render_report) and the ManifestError path
+# Commit 2 adds JsonRenderer for --json output mode and extends the
+# Renderer protocol with render_manifest_error so both renderer
+# implementations can surface manifest-load failures through their
+# declared output format. main() chooses the renderer and routes both
+# the success path (render_report) and the ManifestError path
 # (render_manifest_error) through it. Human mode keeps writing
 # ManifestError to stderr; JSON mode writes the manifest-error envelope
-# from PR V8.2-3 design checkpoint section 2 to stdout (JSON consumers
-# parse a single stream).
+# from PR V8.2-3 design checkpoint §2 to stdout (JSON consumers parse a
+# single stream).
 #
-# Commit 3 will add --filter-mode / --filter-id flags, the 8-token
-# diagnostic taxonomy, summary.diagnostic="no_vectors_selected" handling,
-# and populate results[].reason_code (which commit 2 leaves null for
-# both passing and failing vectors per the staged-refactor lock).
+# Commit 3 (this commit) adds filter-aware selection plumbing + the
+# 8-token diagnostic taxonomy + summary.diagnostic /
+# summary.message for the no_vectors_selected case. results[].reason_code
+# is now populated (commits 1+2 left it null pending this commit's
+# taxonomy work). The JsonRenderer carries a defensive fallback for the
+# reason_code and message fields per the design lock: a failing vector
+# without an explicit reason_code defaults to DC_RUNNER_ERROR, and
+# without a reason defaults to "failed without message". Each failure
+# site in run.py sets both explicitly; the fallback is the safety net
+# for future drift.
 
 
 class Renderer(Protocol):
     """Output renderer protocol for the conformance runner.
 
-    Implementations transform a :class:`RunnerReport` (or a manifest
-    error message) into a string that :func:`main` writes to stdout
-    (or stderr for human-mode manifest errors). The renderer
-    abstraction is the seam on which the v0.8.2 PR V8.2-3 follow-up
+    Two operations:
+
+      - :meth:`render_report` for a populated :class:`RunnerReport`
+        (success path, vector failures, and the no_vectors_selected
+        diagnostic).
+      - :meth:`render_manifest_error` for the manifest-load failure
+        path, which short-circuits before any RunnerReport is built.
+
+    The protocol is the seam on which the v0.8.2 PR V8.2-3 follow-up
     commits build:
 
-      - Commit 2 (this commit): ``JsonRenderer`` emits the JSON document
-        defined in the design checkpoint section 2, including the
-        explicit manifest-error envelope.
-      - Commit 3: filter-aware selection plumbing + the 8-token
-        diagnostic taxonomy are added; the renderer signature grows to
-        accept the selection block so JSON output's
-        ``selection.filter_modes`` / ``selection.filter_ids`` fields
-        can be populated, and ``results[].reason_code`` becomes non-null
-        for failing vectors.
+      - Commit 2 added JsonRenderer + render_manifest_error.
+      - Commit 3 added selection plumbing + 8-token taxonomy +
+        no_vectors_selected diagnostic. JsonRenderer surfaces the
+        per-vector token in ``results[].reason_code`` and the summary
+        token in ``summary.diagnostic``; HumanRenderer keeps the
+        existing freeform per-vector reason text and renders summary
+        diagnostics in a dedicated block.
     """
 
     def render_report(self, report: RunnerReport, *, verbose: bool) -> str:
@@ -278,7 +445,7 @@ class Renderer(Protocol):
         returns the freeform ``"ManifestError: <message>"`` string that
         v0.8.2 PR V8.2-2 wrote to stderr; :class:`JsonRenderer` returns
         the JSON manifest-error envelope from PR V8.2-3 design
-        checkpoint section 2.
+        checkpoint §2.
 
         ``manifest_version`` is populated by the caller iff it was
         readable before the validation failure point. The human form
@@ -291,27 +458,37 @@ class Renderer(Protocol):
 class HumanRenderer:
     """Default human-readable text renderer.
 
-    Output is byte-identical to v0.8.2 PR V8.2-2
-    ``RunnerReport.format_summary()`` (whose body this method replaces;
-    ``format_summary`` is retained as a delegating compatibility shim).
+    Default-invocation output (no filters, no diagnostic) is
+    byte-identical to v0.8.2 PR V8.2-2 ``RunnerReport.format_summary()``
+    — see the per-commit SHA256 verification gate.
+
     Format:
 
-      - Header block: runner name, manifest version, total vector count,
-        blank line.
+      - Header block: runner name, manifest version, total vector
+        count, blank line.
       - One line per vector: ``  {PASS|FAIL}  {id}``.
-      - Indented (8-space) reason lines on failure, or when ``verbose=True``
-        AND the result carries a non-empty ``reason`` string.
+      - Indented (8-space) reason lines on failure, or when
+        ``verbose=True`` AND the result carries a non-empty ``reason``
+        string.
       - Blank line.
       - Final ``Summary: X/Y passed`` line; suffix ``(Z failed)`` when
         not all vectors passed.
 
-    Manifest-error form (added in commit 2) returns the byte-identical
-    ``"ManifestError: <message>"`` string that v0.8.2 PR V8.2-2 wrote to
-    stderr; :func:`main` continues to send it to stderr in human mode.
+    Format extensions over commit 2:
 
-    The byte-equivalence claim is verified at each PR V8.2-3 commit save
-    time by SHA256-comparing pre-save and post-save default-invocation
-    stdout.
+      - When ``report.selection`` carries non-empty filter values, the
+        header gains ``Filter modes:`` and/or ``Filter ids:`` lines
+        and a ``Selected: X of Y`` line. Default invocation skips this
+        block entirely (preserves the byte-identical SHA).
+      - When ``report.diagnostic`` is set (currently only
+        ``"no_vectors_selected"``), the per-vector block is replaced
+        with a ``Diagnostic: <token>`` line + indented ``message`` and
+        a one-line summary ``Summary: 0 vectors selected by filter``.
+
+    Manifest-error form (added in commit 2) returns the byte-identical
+    ``"ManifestError: <message>"`` string that v0.8.2 PR V8.2-2 wrote
+    to stderr; :func:`main` continues to send it to stderr in human
+    mode.
     """
 
     def render_report(self, report: RunnerReport, *, verbose: bool) -> str:
@@ -319,8 +496,36 @@ class HumanRenderer:
             "PIC Conformance Runner v0.1",
             f"Manifest version: {report.manifest_version}",
             f"Vectors:          {report.total_count}",
-            "",
         ]
+
+        # Filter header — surfaces only when filters were applied.
+        # Default no-filter invocations skip this block, preserving the
+        # byte-identical output across commits 1, 2, and 3.
+        if report.selection.filter_modes or report.selection.filter_ids:
+            if report.selection.filter_modes:
+                lines.append(f"Filter modes:     {report.selection.filter_modes}")
+            if report.selection.filter_ids:
+                lines.append(f"Filter ids:       {report.selection.filter_ids}")
+            lines.append(
+                f"Selected:         {report.selection.selected} of "
+                f"{report.selection.total_in_manifest}"
+            )
+
+        lines.append("")
+
+        # Diagnostic short-circuit (no_vectors_selected). No per-vector
+        # results to iterate; render the diagnostic block and a one-line
+        # summary, then return.
+        if report.diagnostic is not None:
+            lines.append(f"Diagnostic: {report.diagnostic}")
+            if report.message:
+                for ml in report.message.splitlines():
+                    lines.append(f"        {ml}")
+            lines.append("")
+            lines.append("Summary: 0 vectors selected by filter")
+            return "\n".join(lines)
+
+        # Normal per-vector block — unchanged behavior from commits 1+2.
         for r in report.results:
             status = "PASS" if r.passed else "FAIL"
             lines.append(f"  {status}  {r.id}")
@@ -331,7 +536,7 @@ class HumanRenderer:
         if report.all_passed:
             lines.append(f"Summary: {report.passed_count}/{report.total_count} passed")
         else:
-            failed = report.total_count - report.passed_count
+            failed = report.failed_count
             lines.append(
                 f"Summary: {report.passed_count}/{report.total_count} passed ({failed} failed)"
             )
@@ -360,34 +565,30 @@ class JsonRenderer:
     """JSON output renderer for the conformance runner.
 
     Emits the JSON document defined in v0.8.2 PR V8.2-3 design checkpoint
-    section 2. Output is pretty-printed (2-space indent) to stdout. The
+    §2. Output is pretty-printed (2-space indent) to stdout. The
     renderer is the sole producer of output when ``--json`` is set;
     ``--verbose`` is accepted but has no effect (JSON always carries
     full per-vector detail).
 
-    Commit-staged contract notes (refined in subsequent PR V8.2-3 commits):
+    Defensive fallbacks for failing vectors per the design lock:
 
-      - In commit 2 (this commit), ``results[].reason_code`` is ``null``
-        for both passing AND failing vectors; the 8-token diagnostic
-        taxonomy populates the field in commit 3. The freeform
-        ``results[].message`` field carries the existing failure-reason
-        string verbatim in the meantime, so debuggability is preserved
-        across the staged refactor.
-      - In commit 2, ``summary.diagnostic`` and ``summary.message`` are
-        ``null`` for normal-run reports. They become non-null in commit
-        3 when ``--filter-*`` selects zero vectors (diagnostic
-        ``"no_vectors_selected"``). The manifest-error envelope path
-        uses ``summary.diagnostic="manifest_invalid"`` already in this
-        commit (see :meth:`render_manifest_error`).
-      - ``selection.filter_modes`` / ``selection.filter_ids`` are always
-        empty lists in commit 2 (no filter flags exist yet); commit 3
-        populates them.
+      - ``results[].reason_code``: a failing vector without an explicit
+        ``reason_code`` defaults to :data:`DC_RUNNER_ERROR` rather than
+        leaking a schema-violating null.
+      - ``results[].message``: a failing vector without an explicit
+        ``reason`` defaults to ``"failed without message"`` rather than
+        leaking a schema-violating null.
+
+    Both are last-resort safety nets — each failure site in
+    :mod:`conformance.run` sets both fields explicitly. The fallbacks
+    catch future drift if a contributor adds a failure site and forgets
+    a keyword.
 
     Manifest-error envelope ``summary.message`` is rendered as
     ``"ManifestError: <message>"`` — the same prefix
     :class:`HumanRenderer` uses for stderr. The prefix is part of the
-    locked PR V8.2-3 design checkpoint section 2 shape so JSON consumers
-    and humans see the same error string format.
+    locked PR V8.2-3 design checkpoint §2 shape so JSON consumers and
+    humans see the same error string format.
     """
 
     def render_report(self, report: RunnerReport, *, verbose: bool) -> str:
@@ -396,38 +597,46 @@ class JsonRenderer:
         del verbose
         results_json: List[Dict[str, Any]] = []
         for r in report.results:
+            if r.passed:
+                rc: Optional[str] = None
+                msg: Optional[str] = None
+            else:
+                # Defensive fallbacks per design lock: passed=False with
+                # a missing reason_code defaults to DC_RUNNER_ERROR, and
+                # a missing reason defaults to "failed without message".
+                # Both keep the JSON schema-valid (reason_code/message
+                # non-null iff passed:false) even if a future failure
+                # site forgets a keyword. Each existing failure site
+                # sets both fields explicitly; these are safety nets.
+                rc = r.reason_code or DC_RUNNER_ERROR
+                msg = r.reason or "failed without message"
             results_json.append(
                 {
                     "id": r.id,
                     "mode": r.mode,
                     "passed": r.passed,
-                    # reason_code is None in commit 2 for both passing and
-                    # failing vectors; commit 3 populates with the 8-token
-                    # diagnostic taxonomy. Freeform `message` carries the
-                    # legacy reason string verbatim so failing-vector
-                    # diagnostics remain visible during the staged refactor.
-                    "reason_code": None,
-                    "message": r.reason if (not r.passed and r.reason) else None,
+                    "reason_code": rc,
+                    "message": msg,
                 }
             )
         envelope: Dict[str, Any] = {
             "manifest_version": report.manifest_version,
             "selection": {
-                "total_in_manifest": report.total_count,
-                "selected": report.total_count,
-                "filter_modes": [],
-                "filter_ids": [],
+                "total_in_manifest": report.selection.total_in_manifest,
+                "selected": report.selection.selected,
+                "filter_modes": list(report.selection.filter_modes),
+                "filter_ids": list(report.selection.filter_ids),
             },
             "results": results_json,
             "summary": {
                 "total": report.total_count,
                 "passed": report.passed_count,
-                "failed": report.total_count - report.passed_count,
+                "failed": report.failed_count,
                 "all_passed": report.all_passed,
-                "diagnostic": None,
-                "message": None,
+                "diagnostic": report.diagnostic,
+                "message": report.message,
             },
-            "exit_code": 0 if report.all_passed else 1,
+            "exit_code": report.exit_code,
         }
         return json.dumps(envelope, indent=2)
 
@@ -437,19 +646,27 @@ class JsonRenderer:
         *,
         manifest_version: Optional[str] = None,
     ) -> str:
-        """Render the JSON manifest-error envelope per design checkpoint section 2.
+        """Render the JSON manifest-error envelope per design checkpoint §2.
 
         ``manifest_version`` may be populated if the manifest's top-level
         ``version`` field was readable before the validation failure
         point; otherwise ``None``. In commit 2 the runner always passes
         ``None`` (no fine-grained "we got past version parsing" signal
-        from :func:`_validate_manifest`); commit 3 may refine if the
-        differentiation becomes useful for operators.
+        from :func:`_validate_manifest`); commit 3 preserves this — if
+        the differentiation becomes useful for operators it can be
+        refined in a later PR.
 
         ``summary.message`` is rendered with the ``"ManifestError: "``
         prefix — same as the :class:`HumanRenderer` stderr form — per
-        the PR V8.2-3 design checkpoint section 2 lock. JSON consumers
-        and humans observe the same error string format.
+        the PR V8.2-3 design checkpoint §2 lock. JSON consumers and
+        humans observe the same error string format.
+
+        Selection is reported as zero/empty because manifest validation
+        failed before filter resolution. Operator-passed filter
+        arguments are intentionally not reflected here — the envelope's
+        purpose is to surface the parse/schema failure, not the
+        operator's filter intent. The freeform ``message`` carries the
+        failure detail.
         """
         envelope: Dict[str, Any] = {
             "manifest_version": manifest_version,
@@ -465,7 +682,7 @@ class JsonRenderer:
                 "passed": 0,
                 "failed": 0,
                 "all_passed": False,
-                "diagnostic": "manifest_invalid",
+                "diagnostic": DC_MANIFEST_INVALID,
                 "message": f"ManifestError: {message}",
             },
             "exit_code": 2,
@@ -662,6 +879,42 @@ def _check_vector_file_agrees_with_entry(
 
 
 # ---------------------------------------------------------------------------
+# Filter resolution (v0.8.2 PR V8.2-3 commit 3)
+# ---------------------------------------------------------------------------
+
+
+def _apply_filters(
+    entries: List[Dict[str, Any]],
+    *,
+    filter_modes: Optional[List[str]],
+    filter_ids: Optional[List[str]],
+) -> List[Dict[str, Any]]:
+    """Return entries selected by the union of mode + id filters.
+
+    Semantics (design checkpoint §1, §4):
+
+      - No filters set → all entries returned (default behavior).
+      - One or more ``--filter-mode`` flags → set of allowed modes.
+      - One or more ``--filter-id`` flags → set of allowed ids.
+      - When BOTH filter kinds are present, an entry is selected if its
+        mode is in ``filter_modes`` OR its id is in ``filter_ids``
+        (union across kinds; rationale per §1: union avoids the
+        common-case foot-gun where ``--filter-mode evidence
+        --filter-id canon-001-basic-object`` produces an empty
+        intersection).
+      - Unknown mode names and unknown ids are not validated here; they
+        simply select nothing. The empty-selection-with-non-empty-filters
+        case is detected by :func:`run_manifest` and surfaces as
+        ``summary.diagnostic="no_vectors_selected"`` + exit 2.
+    """
+    fmodes = set(filter_modes or [])
+    fids = set(filter_ids or [])
+    if not fmodes and not fids:
+        return list(entries)
+    return [e for e in entries if e["mode"] in fmodes or e["id"] in fids]
+
+
+# ---------------------------------------------------------------------------
 # Per-mode vector execution
 # ---------------------------------------------------------------------------
 
@@ -679,6 +932,7 @@ def _run_canonicalization_vector(vec: Dict[str, Any]) -> VectorResult:
             mode="canonicalization",
             passed=False,
             reason=f"vector file missing required field: {e}",
+            reason_code=DC_VECTOR_INVALID,
         )
 
     try:
@@ -689,6 +943,7 @@ def _run_canonicalization_vector(vec: Dict[str, Any]) -> VectorResult:
             mode="canonicalization",
             passed=False,
             reason=f"canonicalize() raised {type(e).__name__}: {e}",
+            reason_code=DC_RUNNER_ERROR,
         )
 
     actual_hex = actual_bytes.hex()
@@ -700,6 +955,7 @@ def _run_canonicalization_vector(vec: Dict[str, Any]) -> VectorResult:
             reason=(
                 f"canonical bytes mismatch\n  expected: {expected_hex}\n  actual:   {actual_hex}"
             ),
+            reason_code=DC_CANONICALIZATION_MISMATCH,
         )
 
     actual_sha = hashlib.sha256(actual_bytes).hexdigest()
@@ -709,6 +965,7 @@ def _run_canonicalization_vector(vec: Dict[str, Any]) -> VectorResult:
             mode="canonicalization",
             passed=False,
             reason=(f"SHA-256 mismatch\n  expected: {expected_sha}\n  actual:   {actual_sha}"),
+            reason_code=DC_CANONICALIZATION_MISMATCH,
         )
 
     return VectorResult(id=vid, mode="canonicalization", passed=True)
@@ -730,10 +987,25 @@ def _run_core_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorResult
             mode="core",
             passed=False,
             reason="vector file missing required field: 'proposal'",
+            reason_code=DC_VECTOR_INVALID,
         )
 
     proposal = vec["proposal"]
     options_dict = vec.get("options", {})
+
+    # Defensive type guard, parallel to evidence/trust_sanitization modes.
+    # Without this, PipelineOptions construction or verify_proposal would
+    # leak an AttributeError / TypeError on non-dict proposals (e.g. list,
+    # string). Fail-closed with a clear reason instead.
+    if not isinstance(proposal, dict):
+        return VectorResult(
+            id=vid,
+            mode="core",
+            passed=False,
+            reason="vector file field 'proposal' must be an object",
+            reason_code=DC_VECTOR_INVALID,
+        )
+
     try:
         options = PipelineOptions(**options_dict)
     except Exception as e:
@@ -742,6 +1014,7 @@ def _run_core_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorResult
             mode="core",
             passed=False,
             reason=f"could not construct PipelineOptions: {type(e).__name__}: {e}",
+            reason_code=DC_VECTOR_INVALID,
         )
 
     try:
@@ -754,6 +1027,7 @@ def _run_core_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorResult
             mode="core",
             passed=False,
             reason=f"verify_proposal() raised {type(e).__name__}: {e}",
+            reason_code=DC_RUNNER_ERROR,
         )
 
     if entry["expected"] == "allow":
@@ -761,13 +1035,21 @@ def _run_core_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorResult
             return VectorResult(id=vid, mode="core", passed=True)
         code = result.error.code.value if (result.error and result.error.code) else "<none>"
         return VectorResult(
-            id=vid, mode="core", passed=False, reason=f"expected allow but got block ({code})"
+            id=vid,
+            mode="core",
+            passed=False,
+            reason=f"expected allow but got block ({code})",
+            reason_code=DC_VERDICT_MISMATCH,
         )
 
     # expected == "block"
     if result.ok:
         return VectorResult(
-            id=vid, mode="core", passed=False, reason="expected block but proposal was allowed"
+            id=vid,
+            mode="core",
+            passed=False,
+            reason="expected block but proposal was allowed",
+            reason_code=DC_VERDICT_MISMATCH,
         )
     if result.error is None or result.error.code is None:
         return VectorResult(
@@ -775,6 +1057,7 @@ def _run_core_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorResult
             mode="core",
             passed=False,
             reason="expected block with error code, got block with no error code",
+            reason_code=DC_ERROR_CODE_MISMATCH,
         )
     actual_code = result.error.code.value
     expected_code = entry["expected_error_code"]
@@ -784,6 +1067,7 @@ def _run_core_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorResult
             mode="core",
             passed=False,
             reason=f"expected {expected_code} but got {actual_code}",
+            reason_code=DC_ERROR_CODE_MISMATCH,
         )
     return VectorResult(id=vid, mode="core", passed=True)
 
@@ -932,6 +1216,7 @@ def _run_evidence_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorRe
             mode="evidence",
             passed=False,
             reason="vector file missing required field: 'proposal'",
+            reason_code=DC_VECTOR_INVALID,
         )
 
     # Enforce that evidence vectors declare options AND set verify_evidence=true.
@@ -944,6 +1229,7 @@ def _run_evidence_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorRe
             mode="evidence",
             passed=False,
             reason="evidence vector missing required object field: 'options'",
+            reason_code=DC_VECTOR_INVALID,
         )
 
     options_dict = vec["options"]
@@ -957,6 +1243,7 @@ def _run_evidence_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorRe
             mode="evidence",
             passed=False,
             reason="evidence vector options must not declare key_resolver; use embedded_keyring",
+            reason_code=DC_VECTOR_INVALID,
         )
 
     # Prevent a vector JSON from declaring proposal_base_dir directly. The
@@ -972,6 +1259,7 @@ def _run_evidence_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorRe
                 "evidence vector options must not declare proposal_base_dir; "
                 "the runner derives it from evidence_root_dir"
             ),
+            reason_code=DC_VECTOR_INVALID,
         )
 
     if options_dict.get("verify_evidence") is not True:
@@ -980,6 +1268,7 @@ def _run_evidence_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorRe
             mode="evidence",
             passed=False,
             reason="evidence vector must set options.verify_evidence=true",
+            reason_code=DC_VECTOR_INVALID,
         )
 
     proposal = vec["proposal"]
@@ -993,6 +1282,7 @@ def _run_evidence_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorRe
             mode="evidence",
             passed=False,
             reason="vector file field 'proposal' must be an object",
+            reason_code=DC_VECTOR_INVALID,
         )
 
     # Hermeticity guards: prevent fallback to env-var keyring or CWD-based
@@ -1008,6 +1298,7 @@ def _run_evidence_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorRe
             mode="evidence",
             passed=False,
             reason="signature evidence vector must declare object field embedded_keyring",
+            reason_code=DC_VECTOR_INVALID,
         )
 
     if _proposal_contains_file_hash_evidence(proposal):
@@ -1021,6 +1312,7 @@ def _run_evidence_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorRe
                     "file-backed hash evidence vector must set non-empty "
                     "string options.evidence_root_dir"
                 ),
+                reason_code=DC_VECTOR_INVALID,
             )
 
     # Build key_resolver from embedded_keyring (if any)
@@ -1032,6 +1324,7 @@ def _run_evidence_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorRe
             mode="evidence",
             passed=False,
             reason=f"could not build key_resolver from embedded_keyring: {type(e).__name__}: {e}",
+            reason_code=DC_VECTOR_INVALID,
         )
 
     # Resolve evidence_root_dir against repo root (rejects absolute paths,
@@ -1045,6 +1338,7 @@ def _run_evidence_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorRe
             mode="evidence",
             passed=False,
             reason=f"could not resolve evidence_root_dir: {type(e).__name__}: {e}",
+            reason_code=DC_VECTOR_INVALID,
         )
 
     # Derive proposal_base_dir from the resolved evidence_root_dir so that
@@ -1070,6 +1364,7 @@ def _run_evidence_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorRe
             mode="evidence",
             passed=False,
             reason=f"could not construct PipelineOptions: {type(e).__name__}: {e}",
+            reason_code=DC_VECTOR_INVALID,
         )
 
     try:
@@ -1082,6 +1377,7 @@ def _run_evidence_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorRe
             mode="evidence",
             passed=False,
             reason=f"verify_proposal() raised {type(e).__name__}: {e}",
+            reason_code=DC_RUNNER_ERROR,
         )
 
     if entry["expected"] == "allow":
@@ -1093,6 +1389,7 @@ def _run_evidence_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorRe
             mode="evidence",
             passed=False,
             reason=f"expected allow but got block ({code})",
+            reason_code=DC_VERDICT_MISMATCH,
         )
 
     # expected == "block"
@@ -1102,6 +1399,7 @@ def _run_evidence_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorRe
             mode="evidence",
             passed=False,
             reason="expected block but proposal was allowed",
+            reason_code=DC_VERDICT_MISMATCH,
         )
     if result.error is None or result.error.code is None:
         return VectorResult(
@@ -1109,6 +1407,7 @@ def _run_evidence_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorRe
             mode="evidence",
             passed=False,
             reason="expected block with error code, got block with no error code",
+            reason_code=DC_ERROR_CODE_MISMATCH,
         )
     actual_code = result.error.code.value
     expected_code = entry["expected_error_code"]
@@ -1118,6 +1417,7 @@ def _run_evidence_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -> VectorRe
             mode="evidence",
             passed=False,
             reason=f"expected {expected_code} but got {actual_code}",
+            reason_code=DC_ERROR_CODE_MISMATCH,
         )
     return VectorResult(id=vid, mode="evidence", passed=True)
 
@@ -1170,6 +1470,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
             mode="trust_sanitization",
             passed=False,
             reason="vector file missing required field: 'proposal'",
+            reason_code=DC_VECTOR_INVALID,
         )
 
     # Options must be present as an object. The matrix coordinate
@@ -1181,6 +1482,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
             mode="trust_sanitization",
             passed=False,
             reason="trust_sanitization vector missing required object field: 'options'",
+            reason_code=DC_VECTOR_INVALID,
         )
 
     options_dict = vec["options"]
@@ -1192,6 +1494,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
             mode="trust_sanitization",
             passed=False,
             reason="trust_sanitization vector must declare options.strict_trust",
+            reason_code=DC_VECTOR_INVALID,
         )
     if "verify_evidence" not in options_dict:
         return VectorResult(
@@ -1199,6 +1502,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
             mode="trust_sanitization",
             passed=False,
             reason="trust_sanitization vector must declare options.verify_evidence",
+            reason_code=DC_VECTOR_INVALID,
         )
 
     # Both matrix axes MUST be actual booleans. JSON true/false → Python bool.
@@ -1211,6 +1515,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
             mode="trust_sanitization",
             passed=False,
             reason="trust_sanitization vector options.strict_trust must be boolean",
+            reason_code=DC_VECTOR_INVALID,
         )
     if not isinstance(options_dict["verify_evidence"], bool):
         return VectorResult(
@@ -1218,6 +1523,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
             mode="trust_sanitization",
             passed=False,
             reason="trust_sanitization vector options.verify_evidence must be boolean",
+            reason_code=DC_VECTOR_INVALID,
         )
 
     # Reject smuggling of runner-controlled fields (same convention as
@@ -1228,6 +1534,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
             mode="trust_sanitization",
             passed=False,
             reason="trust_sanitization vector options must not declare key_resolver",
+            reason_code=DC_VECTOR_INVALID,
         )
     if "proposal_base_dir" in options_dict:
         return VectorResult(
@@ -1238,6 +1545,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
                 "trust_sanitization vector options must not declare proposal_base_dir; "
                 "the runner derives it from evidence_root_dir"
             ),
+            reason_code=DC_VECTOR_INVALID,
         )
 
     # Coordinate consistency check: the vector id and manifest file path
@@ -1262,6 +1570,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
                 f"coordinate/id mismatch: options imply id={expected_id!r}, "
                 f"vector file declares id={vec['id']!r}"
             ),
+            reason_code=DC_VECTOR_INVALID,
         )
     if entry["file"] != expected_file:
         return VectorResult(
@@ -1272,6 +1581,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
                 f"coordinate/file mismatch: options imply file={expected_file!r}, "
                 f"manifest declares file={entry['file']!r}"
             ),
+            reason_code=DC_VECTOR_INVALID,
         )
 
     # Reject top-level embedded_keyring. In this mode it would be silently
@@ -1287,6 +1597,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
                 "trust_sanitization vectors must not declare embedded_keyring; "
                 "use evidence mode for signature-evidence conformance"
             ),
+            reason_code=DC_VECTOR_INVALID,
         )
 
     proposal = vec["proposal"]
@@ -1297,6 +1608,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
             mode="trust_sanitization",
             passed=False,
             reason="vector file field 'proposal' must be an object",
+            reason_code=DC_VECTOR_INVALID,
         )
 
     # Reject sig evidence in trust_sanitization mode. This mode does NOT
@@ -1315,6 +1627,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
                 "trust_sanitization vectors must not contain sig evidence; "
                 "use evidence mode for signature-evidence conformance"
             ),
+            reason_code=DC_VECTOR_INVALID,
         )
 
     # Hermeticity guard for the financial_hash_ok matrix cells: if the
@@ -1332,6 +1645,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
                     "trust_sanitization vector with file-backed hash evidence must set "
                     "non-empty string options.evidence_root_dir"
                 ),
+                reason_code=DC_VECTOR_INVALID,
             )
 
     # Resolve evidence_root_dir against repo root (reuses the evidence-mode
@@ -1345,6 +1659,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
             mode="trust_sanitization",
             passed=False,
             reason=f"could not resolve evidence_root_dir: {type(e).__name__}: {e}",
+            reason_code=DC_VECTOR_INVALID,
         )
 
     # Derive proposal_base_dir from the resolved evidence_root_dir so
@@ -1363,6 +1678,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
             mode="trust_sanitization",
             passed=False,
             reason=f"could not construct PipelineOptions: {type(e).__name__}: {e}",
+            reason_code=DC_VECTOR_INVALID,
         )
 
     try:
@@ -1375,6 +1691,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
             mode="trust_sanitization",
             passed=False,
             reason=f"verify_proposal() raised {type(e).__name__}: {e}",
+            reason_code=DC_RUNNER_ERROR,
         )
 
     if entry["expected"] == "allow":
@@ -1386,6 +1703,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
             mode="trust_sanitization",
             passed=False,
             reason=f"expected allow but got block ({code})",
+            reason_code=DC_VERDICT_MISMATCH,
         )
 
     # expected == "block"
@@ -1395,6 +1713,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
             mode="trust_sanitization",
             passed=False,
             reason="expected block but proposal was allowed",
+            reason_code=DC_VERDICT_MISMATCH,
         )
     if result.error is None or result.error.code is None:
         return VectorResult(
@@ -1402,6 +1721,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
             mode="trust_sanitization",
             passed=False,
             reason="expected block with error code, got block with no error code",
+            reason_code=DC_ERROR_CODE_MISMATCH,
         )
     actual_code = result.error.code.value
     expected_code = entry["expected_error_code"]
@@ -1411,6 +1731,7 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
             mode="trust_sanitization",
             passed=False,
             reason=f"expected {expected_code} but got {actual_code}",
+            reason_code=DC_ERROR_CODE_MISMATCH,
         )
     return VectorResult(id=vid, mode="trust_sanitization", passed=True)
 
@@ -1420,8 +1741,20 @@ def _run_trust_sanitization_vector(vec: Dict[str, Any], entry: Dict[str, Any]) -
 # ---------------------------------------------------------------------------
 
 
-def run_manifest(manifest_path: Path) -> RunnerReport:
-    """Load and validate a manifest, execute every vector, return aggregate report.
+def run_manifest(
+    manifest_path: Path,
+    *,
+    filter_modes: Optional[List[str]] = None,
+    filter_ids: Optional[List[str]] = None,
+) -> RunnerReport:
+    """Load and validate a manifest, execute every selected vector, return aggregate report.
+
+    ``filter_modes`` / ``filter_ids`` are optional union filters per
+    design checkpoint §1 (see :func:`_apply_filters`). When neither is
+    set, all manifest vectors are selected. When set and the filter
+    selects zero vectors, the returned report has
+    ``diagnostic=DC_NO_VECTORS_SELECTED`` + a freeform message + an
+    empty ``results`` list; :func:`main` then exits 2 per §5.
 
     Raises:
         ManifestError: if the manifest itself is malformed. Per-vector
@@ -1442,9 +1775,32 @@ def run_manifest(manifest_path: Path) -> RunnerReport:
     _validate_manifest(manifest)
 
     conformance_root = manifest_path.resolve().parent
-    report = RunnerReport(manifest_version=manifest["version"])
+    all_entries = manifest["vectors"]
+    selected_entries = _apply_filters(all_entries, filter_modes=filter_modes, filter_ids=filter_ids)
+    selection = Selection(
+        total_in_manifest=len(all_entries),
+        selected=len(selected_entries),
+        filter_modes=list(filter_modes or []),
+        filter_ids=list(filter_ids or []),
+    )
+    report = RunnerReport(
+        manifest_version=manifest["version"],
+        selection=selection,
+    )
 
-    for entry in manifest["vectors"]:
+    # Empty selection with non-empty filters → diagnostic + exit 2 per §4.
+    # Empty manifest with no filters → vacuous success (all_passed=True,
+    # exit_code=0) per §5; no diagnostic.
+    if not selected_entries and (filter_modes or filter_ids):
+        report.diagnostic = DC_NO_VECTORS_SELECTED
+        report.message = (
+            f"filter selected zero vectors "
+            f"(filter_modes={list(filter_modes or [])}, "
+            f"filter_ids={list(filter_ids or [])})"
+        )
+        return report
+
+    for entry in selected_entries:
         vec_path = conformance_root / entry["file"]
         if not vec_path.exists():
             report.results.append(
@@ -1453,6 +1809,7 @@ def run_manifest(manifest_path: Path) -> RunnerReport:
                     mode=entry["mode"],
                     passed=False,
                     reason=f"vector file not found: {entry['file']}",
+                    reason_code=DC_MANIFEST_DRIFT,
                 )
             )
             continue
@@ -1466,6 +1823,22 @@ def run_manifest(manifest_path: Path) -> RunnerReport:
                     mode=entry["mode"],
                     passed=False,
                     reason=f"vector file is not valid JSON: {e}",
+                    reason_code=DC_VECTOR_INVALID,
+                )
+            )
+            continue
+
+        # Vector root type guard: a vector file containing `[]`, `"x"`, or
+        # `123` would crash `vec.get("id")` below with AttributeError.
+        # Fail-closed with a clear vector_invalid reason instead.
+        if not isinstance(vec, dict):
+            report.results.append(
+                VectorResult(
+                    id=entry["id"],
+                    mode=entry["mode"],
+                    passed=False,
+                    reason="vector file root must be a JSON object",
+                    reason_code=DC_VECTOR_INVALID,
                 )
             )
             continue
@@ -1477,6 +1850,7 @@ def run_manifest(manifest_path: Path) -> RunnerReport:
                     mode=entry["mode"],
                     passed=False,
                     reason=f"id mismatch: manifest={entry['id']!r} file={vec.get('id')!r}",
+                    reason_code=DC_MANIFEST_DRIFT,
                 )
             )
             continue
@@ -1489,6 +1863,7 @@ def run_manifest(manifest_path: Path) -> RunnerReport:
                     mode=entry["mode"],
                     passed=False,
                     reason=f"manifest/vector drift: {drift}",
+                    reason_code=DC_MANIFEST_DRIFT,
                 )
             )
             continue
@@ -1544,17 +1919,46 @@ def main(argv: Optional[List[str]] = None) -> int:
             "single stream."
         ),
     )
+    parser.add_argument(
+        "--filter-mode",
+        action="append",
+        default=None,
+        metavar="MODE",
+        help=(
+            "Run only vectors whose mode matches MODE (one of: "
+            "canonicalization, core, evidence, trust_sanitization). "
+            "Repeatable; multiple flags union together. Unions with "
+            "--filter-id. Unknown mode names select nothing and trigger "
+            "exit 2 with summary.diagnostic='no_vectors_selected'."
+        ),
+    )
+    parser.add_argument(
+        "--filter-id",
+        action="append",
+        default=None,
+        metavar="ID",
+        help=(
+            "Run only the vector with the exact ID. Repeatable; multiple "
+            "flags union together. Unions with --filter-mode. Unknown IDs "
+            "select nothing and trigger exit 2 with "
+            "summary.diagnostic='no_vectors_selected'."
+        ),
+    )
     args = parser.parse_args(argv)
 
     renderer: Renderer = JsonRenderer() if args.json else HumanRenderer()
 
     try:
-        report = run_manifest(Path(args.manifest))
+        report = run_manifest(
+            Path(args.manifest),
+            filter_modes=args.filter_mode,
+            filter_ids=args.filter_id,
+        )
     except ManifestError as e:
         # Human mode: print to stderr (byte-identical to v0.8.2 PR V8.2-2).
         # JSON mode:  print the manifest-error envelope to stdout per the
-        # PR V8.2-3 design checkpoint section 2 lock — JSON consumers MUST
-        # be able to parse a single stream without merging stderr.
+        # PR V8.2-3 design checkpoint §2 lock — JSON consumers MUST be
+        # able to parse a single stream without merging stderr.
         rendered = renderer.render_manifest_error(str(e))
         if args.json:
             print(rendered)
@@ -1562,8 +1966,13 @@ def main(argv: Optional[List[str]] = None) -> int:
             print(rendered, file=sys.stderr)
         return 2
 
+    # Success path AND no_vectors_selected path both render the report.
+    # In human mode, no_vectors_selected output goes to stdout per the
+    # PR V8.2-3 design checkpoint approval: a report with a diagnostic
+    # IS still a report. ManifestError is different — it short-circuits
+    # before the report exists.
     print(renderer.render_report(report, verbose=args.verbose))
-    return 0 if report.all_passed else 1
+    return report.exit_code
 
 
 if __name__ == "__main__":

--- a/conformance/run.py
+++ b/conformance/run.py
@@ -75,7 +75,7 @@ import sys
 import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Protocol
 
 # Ensure sdk-python is importable without install — mirrors tests/conftest.py.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -181,31 +181,129 @@ class RunnerReport:
         return self.total_count > 0 and self.passed_count == self.total_count
 
     def format_summary(self, verbose: bool = False) -> str:
+        """Back-compat shim that delegates to :class:`HumanRenderer`.
+
+        Preserves the v0.8.2 PR V8.2-2 API surface for any out-of-repo or
+        internal caller that imports ``RunnerReport`` and calls
+        ``format_summary()`` directly. New code SHOULD construct a
+        :class:`HumanRenderer` (or any other :class:`Renderer`
+        implementation) and call :meth:`Renderer.render_report` instead.
+
+        Output is byte-identical to
+        ``HumanRenderer().render_report(self, verbose=verbose)`` — the
+        runner CLI uses :class:`HumanRenderer` directly via
+        :func:`main`; this shim exists purely to avoid breaking external
+        callers across the v0.8.2 PR V8.2-3 commit-1 refactor boundary.
+
+        Deprecation timeline: this shim may be removed in a future major
+        version once external usage is confirmed nil. No deprecation
+        warning is emitted in v0.8.2 to keep the refactor truly
+        behavior-preserving at the CLI surface.
+        """
+        return HumanRenderer().render_report(self, verbose=verbose)
+
+
+class ManifestError(Exception):
+    """Raised when the manifest itself is malformed or contains invalid entries."""
+
+
+# ---------------------------------------------------------------------------
+# Output rendering
+# ---------------------------------------------------------------------------
+#
+# v0.8.2 PR V8.2-3 commit 1 introduces a Renderer seam so subsequent commits
+# can add machine-readable output modes (--json in commit 2) and operator
+# filters (--filter-mode / --filter-id in commit 3) without re-touching the
+# orchestrator or CLI entry point. Commit 1 is behavior-preserving: the
+# default invocation produces byte-identical stdout to the v0.8.2 PR V8.2-2
+# baseline (RunnerReport.format_summary semantics, moved verbatim into
+# HumanRenderer.render_report; RunnerReport.format_summary is kept as a
+# delegating compatibility shim).
+#
+# ManifestError handling intentionally stays out of the renderer surface in
+# commit 1. main() retains its existing
+#     except ManifestError as e:
+#         print(f"ManifestError: {e}", file=sys.stderr)
+#         return 2
+# contract from v0.8.2 PR V8.2-2. Routing manifest-error envelopes through
+# the renderer lands in commit 2 alongside the --json output mode, when the
+# JSON manifest-error envelope shape defined in the PR V8.2-3 design
+# checkpoint §2 needs a structured rendering path.
+
+
+class Renderer(Protocol):
+    """Output renderer protocol for the conformance runner.
+
+    Implementations transform a :class:`RunnerReport` into a string that
+    :func:`main` writes to stdout. The renderer abstraction is the seam
+    on which the v0.8.2 PR V8.2-3 follow-up commits build:
+
+      - Commit 2: ``JsonRenderer`` emits the JSON document defined in the
+        design checkpoint §2 (including the explicit manifest-error
+        envelope; commit 2 also routes ``ManifestError`` through this
+        renderer rather than the bare stderr print).
+      - Commit 3: filter-aware selection plumbing + the 8-token diagnostic
+        taxonomy are added; the renderer signature grows to accept the
+        selection block so JSON output's ``selection.filter_modes`` /
+        ``selection.filter_ids`` fields can be populated.
+
+    Commit 1 keeps the surface minimal: one method, one parameter beyond
+    the report itself.
+    """
+
+    def render_report(self, report: RunnerReport, *, verbose: bool) -> str:
+        """Return a string representation of ``report`` for printing.
+
+        The returned string does NOT include a trailing newline; the
+        caller's ``print()`` supplies it. Matches the v0.8.2 PR V8.2-2
+        ``RunnerReport.format_summary()`` contract.
+        """
+        ...
+
+
+class HumanRenderer:
+    """Default human-readable text renderer.
+
+    Output is byte-identical to v0.8.2 PR V8.2-2
+    ``RunnerReport.format_summary()`` (whose body this method replaces;
+    ``format_summary`` is retained as a delegating compatibility shim).
+    Format:
+
+      - Header block: runner name, manifest version, total vector count,
+        blank line.
+      - One line per vector: ``  {PASS|FAIL}  {id}``.
+      - Indented (8-space) reason lines on failure, or when ``verbose=True``
+        AND the result carries a non-empty ``reason`` string.
+      - Blank line.
+      - Final ``Summary: X/Y passed`` line; suffix ``(Z failed)`` when
+        not all vectors passed.
+
+    The byte-equivalence claim is verified at commit 1 save time by
+    SHA256-comparing pre-save and post-save default-invocation stdout.
+    """
+
+    def render_report(self, report: RunnerReport, *, verbose: bool) -> str:
         lines = [
             "PIC Conformance Runner v0.1",
-            f"Manifest version: {self.manifest_version}",
-            f"Vectors:          {self.total_count}",
+            f"Manifest version: {report.manifest_version}",
+            f"Vectors:          {report.total_count}",
             "",
         ]
-        for r in self.results:
+        for r in report.results:
             status = "PASS" if r.passed else "FAIL"
             lines.append(f"  {status}  {r.id}")
             if (not r.passed or verbose) and r.reason:
                 for line in r.reason.splitlines():
                     lines.append(f"        {line}")
         lines.append("")
-        if self.all_passed:
-            lines.append(f"Summary: {self.passed_count}/{self.total_count} passed")
+        if report.all_passed:
+            lines.append(f"Summary: {report.passed_count}/{report.total_count} passed")
         else:
-            failed = self.total_count - self.passed_count
+            failed = report.total_count - report.passed_count
             lines.append(
-                f"Summary: {self.passed_count}/{self.total_count} passed ({failed} failed)"
+                f"Summary: {report.passed_count}/{report.total_count} passed ({failed} failed)"
             )
         return "\n".join(lines)
-
-
-class ManifestError(Exception):
-    """Raised when the manifest itself is malformed or contains invalid entries."""
 
 
 # ---------------------------------------------------------------------------
@@ -1274,10 +1372,16 @@ def main(argv: Optional[List[str]] = None) -> int:
     try:
         report = run_manifest(Path(args.manifest))
     except ManifestError as e:
+        # ManifestError handling stays out of the renderer surface in commit
+        # 1 (PR V8.2-3). Commit 2 will route this through the renderer when
+        # the JSON manifest-error envelope shape from the design checkpoint
+        # §2 lands. The stderr-print + exit-2 contract preserves v0.8.2 PR
+        # V8.2-2 behavior byte-for-byte.
         print(f"ManifestError: {e}", file=sys.stderr)
         return 2
 
-    print(report.format_summary(verbose=args.verbose))
+    renderer: Renderer = HumanRenderer()
+    print(renderer.render_report(report, verbose=args.verbose))
     return 0 if report.all_passed else 1
 
 

--- a/tests/test_conformance_runner.py
+++ b/tests/test_conformance_runner.py
@@ -1,0 +1,392 @@
+"""Subprocess-based CLI tests for ``conformance/run.py`` (v0.8.2 PR V8.2-3 commit 4).
+
+The 10 cases below are locked by the PR V8.2-3 design checkpoint §6. Each
+test invokes ``python -m conformance.run`` via :mod:`subprocess` so the
+real CLI surface (argparse, exit codes, stdout/stderr routing) is
+exercised rather than the in-process Python API.
+
+Counts are derived dynamically from the manifest where possible so the
+suite tolerates future vector additions — tests assert the right SET is
+selected, not hardcoded counts. The single exception is the default
+human-mode test, which pins ``Vectors: {total}`` and
+``Summary: {total}/{total} passed`` explicitly to catch a runner that
+silently selects a partial manifest while still emitting a passing
+summary.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Repo root — used both for cwd of subprocess invocations and for reading
+# the canonical manifest in count-derivation helpers. tests/ is one level
+# under the repo root, so parent.parent resolves correctly.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_MANIFEST_PATH = _REPO_ROOT / "conformance" / "manifest.json"
+
+# Subprocess timeout (seconds). A broken runner should fail fast rather
+# than hang CI. 60s is generous — the full 51-vector run takes <1s
+# locally and the temp-manifest tests are even smaller.
+_SUBPROCESS_TIMEOUT_SECONDS = 60
+
+
+def _run_runner(args: list[str]) -> tuple[int, bytes, bytes]:
+    """Invoke ``python -m conformance.run <args>`` and return (rc, stdout_bytes, stderr_bytes).
+
+    Subprocess-based per design checkpoint §6 — tests exercise the real
+    CLI surface (argparse, exit codes, output streams) rather than
+    ``conformance.run.main`` in-process. ``text=False`` captures raw
+    bytes so JSON parsing is unaffected by the test host's stdout
+    encoding (Windows PowerShell vs POSIX shells write different
+    encodings for redirected stdout — subprocess.run sidesteps that).
+
+    Subprocess has a hard timeout to keep a hung runner from hanging CI.
+    """
+    r = subprocess.run(
+        [sys.executable, "-m", "conformance.run", *args],
+        capture_output=True,
+        text=False,
+        cwd=str(_REPO_ROOT),
+        timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+    )
+    return r.returncode, r.stdout, r.stderr
+
+
+def _run_json(args: list[str], *, expected_rc: int = 0) -> dict:
+    """Invoke ``python -m conformance.run --json <args>``, assert contract, return parsed envelope.
+
+    Centralizes the ``--json`` no-mixed-output contract: every JSON
+    invocation MUST exit with the expected code AND write nothing to
+    stderr (per PR V8.2-3 design checkpoint §2 — JSON consumers parse
+    a single stream). The helper asserts both invariants before
+    returning, so callers don't need to repeat the boilerplate.
+    """
+    rc, out, err = _run_runner(["--json", *args])
+    assert rc == expected_rc, f"expected exit {expected_rc}, got {rc}; stderr={err!r}"
+    assert err == b"", f"--json must not write stderr, got {err!r}"
+    return json.loads(out)
+
+
+def _load_manifest() -> dict:
+    return json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _count_by_mode(mode: str) -> int:
+    return sum(1 for e in _load_manifest()["vectors"] if e["mode"] == mode)
+
+
+# ---------------------------------------------------------------------------
+# §6 case 1: default no-arg run → exits 0, full manifest selected and passed
+# ---------------------------------------------------------------------------
+
+
+def test_default_invocation_all_pass():
+    """Default invocation: full manifest selected, all selected vectors
+    pass, exit 0, stderr empty.
+
+    The Summary line is pinned to ``{total}/{total} passed`` explicitly
+    so a runner that accidentally selected a partial manifest (e.g. a
+    filter regression that defaulted to non-empty filter set) couldn't
+    pass this test by emitting a smaller but still-all-pass summary.
+    """
+    total = len(_load_manifest()["vectors"])
+
+    rc, out, err = _run_runner([])
+    assert rc == 0, f"expected exit 0, got {rc}; stderr={err!r}"
+    assert err == b"", f"expected empty stderr, got {err!r}"
+    text = out.decode("utf-8")
+
+    # Header pins the count of vectors the runner actually iterated.
+    assert f"Vectors:          {total}" in text, (
+        f"expected header 'Vectors:          {total}' in output; got:\n{text}"
+    )
+    # Final summary pins the exact pass count.
+    assert f"Summary: {total}/{total} passed" in text, (
+        f"expected 'Summary: {total}/{total} passed' in output; got:\n{text}"
+    )
+    # All-pass form has no '(N failed)' suffix per HumanRenderer's
+    # contract — defensively check the runner doesn't emit '(0 failed)'.
+    assert "(0 failed)" not in text
+
+
+# ---------------------------------------------------------------------------
+# §6 case 2: --json no filter → valid JSON envelope, all fields per §2 lock
+# ---------------------------------------------------------------------------
+
+
+def test_json_no_filter_envelope_shape():
+    d = _run_json([])
+
+    manifest = _load_manifest()
+    total = len(manifest["vectors"])
+
+    # Top-level envelope.
+    assert d["manifest_version"] == manifest["version"]
+    assert d["exit_code"] == 0
+
+    # Selection block: no filters set → all manifest entries selected.
+    assert d["selection"]["total_in_manifest"] == total
+    assert d["selection"]["selected"] == total
+    assert d["selection"]["filter_modes"] == []
+    assert d["selection"]["filter_ids"] == []
+
+    # Results: one per selected vector; all-pass run → reason_code/message
+    # are None per the "iff passed" contract.
+    assert len(d["results"]) == total
+    for r in d["results"]:
+        assert set(r.keys()) == {"id", "mode", "passed", "reason_code", "message"}
+        assert r["passed"] is True
+        assert r["reason_code"] is None
+        assert r["message"] is None
+
+    # Summary block.
+    assert d["summary"]["total"] == total
+    assert d["summary"]["passed"] == total
+    assert d["summary"]["failed"] == 0
+    assert d["summary"]["all_passed"] is True
+    assert d["summary"]["diagnostic"] is None
+    assert d["summary"]["message"] is None
+
+
+# ---------------------------------------------------------------------------
+# §6 case 3: --filter-mode evidence → selects only evidence vectors
+# ---------------------------------------------------------------------------
+
+
+def test_filter_mode_evidence_selects_only_evidence():
+    d = _run_json(["--filter-mode", "evidence"])
+
+    expected_count = _count_by_mode("evidence")
+    assert expected_count > 0, "manifest has no evidence vectors; test is vacuous"
+
+    assert d["selection"]["filter_modes"] == ["evidence"]
+    assert d["selection"]["selected"] == expected_count
+    assert len(d["results"]) == expected_count
+    assert all(r["mode"] == "evidence" for r in d["results"])
+    assert all(r["passed"] for r in d["results"])
+
+
+# ---------------------------------------------------------------------------
+# §6 case 4: same-kind union via two --filter-mode flags
+# ---------------------------------------------------------------------------
+
+
+def test_filter_mode_union_canonicalization_core():
+    d = _run_json(["--filter-mode", "canonicalization", "--filter-mode", "core"])
+
+    expected_count = _count_by_mode("canonicalization") + _count_by_mode("core")
+    assert d["selection"]["filter_modes"] == ["canonicalization", "core"]
+    assert d["selection"]["selected"] == expected_count
+    assert len(d["results"]) == expected_count
+    modes = {r["mode"] for r in d["results"]}
+    assert modes == {"canonicalization", "core"}
+
+
+# ---------------------------------------------------------------------------
+# §6 case 5: --filter-id <single existing> → selects exactly that vector
+# ---------------------------------------------------------------------------
+
+
+def test_filter_id_single_known():
+    target_id = "canon-001-basic-object"
+    d = _run_json(["--filter-id", target_id])
+
+    assert d["selection"]["filter_ids"] == [target_id]
+    assert d["selection"]["selected"] == 1
+    assert len(d["results"]) == 1
+    assert d["results"][0]["id"] == target_id
+    assert d["results"][0]["passed"] is True
+
+
+# ---------------------------------------------------------------------------
+# §6 case 6: --filter-id <unknown> → exit 2 + no_vectors_selected
+# ---------------------------------------------------------------------------
+
+
+def test_filter_id_unknown_no_vectors_selected():
+    d = _run_json(["--filter-id", "DOES_NOT_EXIST"], expected_rc=2)
+
+    assert d["summary"]["diagnostic"] == "no_vectors_selected"
+    assert d["summary"]["all_passed"] is False
+    assert d["results"] == []
+    assert d["selection"]["filter_ids"] == ["DOES_NOT_EXIST"]
+    assert d["selection"]["selected"] == 0
+    assert d["exit_code"] == 2
+    assert isinstance(d["summary"]["message"], str)
+    assert "DOES_NOT_EXIST" in d["summary"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# §6 case 7: --filter-mode <unknown> (typo case) → exit 2 + no_vectors_selected
+# ---------------------------------------------------------------------------
+
+
+def test_filter_mode_unknown_no_vectors_selected():
+    """A typo'd mode name like 'evidance' must trip exit 2 — silent green
+    on misspelled CI filters would be dangerous."""
+    d = _run_json(["--filter-mode", "evidance"], expected_rc=2)
+
+    assert d["summary"]["diagnostic"] == "no_vectors_selected"
+    assert d["selection"]["filter_modes"] == ["evidance"]
+    assert d["selection"]["selected"] == 0
+    assert d["exit_code"] == 2
+
+
+# ---------------------------------------------------------------------------
+# §6 case 8: cross-kind union (--filter-mode + --filter-id together)
+# ---------------------------------------------------------------------------
+
+
+def test_filter_cross_kind_union():
+    d = _run_json(
+        [
+            "--filter-mode",
+            "evidence",
+            "--filter-id",
+            "canon-001-basic-object",
+        ]
+    )
+
+    selected_ids = {r["id"] for r in d["results"]}
+
+    # Union must include the explicit canon-001 id.
+    assert "canon-001-basic-object" in selected_ids
+
+    # Union must include every evidence-mode vector currently in the manifest.
+    manifest = _load_manifest()
+    expected_evidence_ids = {v["id"] for v in manifest["vectors"] if v["mode"] == "evidence"}
+    assert expected_evidence_ids, "manifest has no evidence vectors; test is vacuous"
+    assert expected_evidence_ids.issubset(selected_ids)
+
+    # And the union should be exactly evidence-mode | {canon-001-basic-object}.
+    assert selected_ids == expected_evidence_ids | {"canon-001-basic-object"}
+
+
+# ---------------------------------------------------------------------------
+# §6 case 9: failure path via temp manifest → reason_code populated under --json
+# ---------------------------------------------------------------------------
+
+
+def test_failing_vector_populates_reason_code(tmp_path: Path):
+    """Lock the §3 taxonomy population: a failing vector exposes a
+    non-null ``reason_code`` and ``message`` per the JsonRenderer
+    contract.
+
+    Constructed scenario: vector expects allow but the proposal will be
+    blocked by the verifier (untrusted-only provenance on money impact),
+    so the runner emits ``reason_code='verdict_mismatch'``.
+    """
+    vec = {
+        "id": "test-verdict-mismatch",
+        "mode": "core",
+        "expected": "allow",
+        "proposal": {
+            "protocol": "PIC/1.0",
+            "intent": "force a verdict mismatch",
+            "impact": "money",
+            "provenance": [{"id": "untrusted_only", "trust": "untrusted"}],
+            "claims": [{"text": "x", "evidence": ["untrusted_only"]}],
+            "action": {"tool": "test.tool", "args": {}},
+        },
+    }
+    (tmp_path / "test_vector.json").write_text(json.dumps(vec), encoding="utf-8")
+    manifest = {
+        "version": "conformance/v0.1",
+        "vectors": [
+            {
+                "id": "test-verdict-mismatch",
+                "file": "test_vector.json",
+                "mode": "core",
+                "expected": "allow",
+            }
+        ],
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    d = _run_json(["--manifest", str(manifest_path)], expected_rc=1)
+
+    assert len(d["results"]) == 1
+    r0 = d["results"][0]
+    assert r0["passed"] is False
+    assert r0["reason_code"] == "verdict_mismatch"
+    assert isinstance(r0["message"], str)
+    assert len(r0["message"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# §6 case 10: exit-code stability under filter (temp manifest, 1 pass + 1 fail)
+# ---------------------------------------------------------------------------
+
+
+def test_filter_isolates_passing_vector_from_unselected_failure(tmp_path: Path):
+    """Lock the §5 exit-code stability contract: a filter that selects
+    only passing vectors exits 0 even when other (unselected) vectors
+    in the manifest would have failed.
+
+    Constructed scenario: a temp manifest with one passing vector and
+    one intentionally failing vector. Baseline full run exits 1 (the
+    failure counts); filtered run targeting only the passing id exits 0.
+    """
+    passing_vec = {
+        "id": "test-passing",
+        "mode": "core",
+        "expected": "allow",
+        "proposal": {
+            "protocol": "PIC/1.0",
+            "intent": "read only",
+            "impact": "read",
+            "provenance": [{"id": "src", "trust": "trusted"}],
+            "claims": [{"text": "x", "evidence": ["src"]}],
+            "action": {"tool": "docs_search", "args": {}},
+        },
+    }
+    failing_vec = {
+        "id": "test-failing",
+        "mode": "core",
+        "expected": "allow",
+        "proposal": {
+            "protocol": "PIC/1.0",
+            "intent": "will fail",
+            "impact": "money",
+            "provenance": [{"id": "untrusted_only", "trust": "untrusted"}],
+            "claims": [{"text": "x", "evidence": ["untrusted_only"]}],
+            "action": {"tool": "test.tool", "args": {}},
+        },
+    }
+    (tmp_path / "passing.json").write_text(json.dumps(passing_vec), encoding="utf-8")
+    (tmp_path / "failing.json").write_text(json.dumps(failing_vec), encoding="utf-8")
+    manifest = {
+        "version": "conformance/v0.1",
+        "vectors": [
+            {"id": "test-passing", "file": "passing.json", "mode": "core", "expected": "allow"},
+            {"id": "test-failing", "file": "failing.json", "mode": "core", "expected": "allow"},
+        ],
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    # Baseline: running ALL vectors must fail (proves the failing vector
+    # really does fail, so the filtered-pass result is meaningful). We
+    # don't inspect the envelope here; just confirm the exit code.
+    _run_json(["--manifest", str(manifest_path)], expected_rc=1)
+
+    # Filtered run: only the passing vector → exit 0.
+    d = _run_json(
+        [
+            "--manifest",
+            str(manifest_path),
+            "--filter-id",
+            "test-passing",
+        ]
+    )
+
+    assert d["selection"]["selected"] == 1
+    assert len(d["results"]) == 1
+    assert d["results"][0]["id"] == "test-passing"
+    assert d["results"][0]["passed"] is True
+    assert d["summary"]["all_passed"] is True
+    assert d["exit_code"] == 0


### PR DESCRIPTION
## Summary

Third PR of the v0.8.2 conformance campaign. Hardens `conformance/run.py` into a CI-grade tool that other implementations (TS verifier in v0.9.0, downstream CI gates) can consume:

- **`--json` output mode** with the explicit envelope shape locked in the design checkpoint (single stdout stream; manifest-error envelope included).
- **`--filter-mode <mode>` / `--filter-id <id>`** (both repeatable, union semantics) so operators can target subsets in CI without parallel runs.
- **8-token diagnostic taxonomy** so machine consumers can pattern-match on a small stable surface; freeform detail still lives in a separate `message` field.
- **Stable exit codes under filter** including the `no_vectors_selected` exit-2 trip-wire that prevents silent CI passes on typo'd filter targets.

Default-invocation human output is **byte-identical** to v0.8.2 PR V8.2-2's baseline (SHA `0E1BD60BF0E6413F88937433BB0B130A153E570487B69C723E4220D9CA8EEA01`) — verified at every commit boundary in the 4-commit campaign. No existing CI consumer of `python -m conformance.run` sees behavior drift.

Implements ROADMAP §1.2 (conformance runner hardening) per the v0.8.2 plan PR V8.2-3.

## Design checkpoint

The work was scoped via an explicit 7-section design checkpoint memo locked before any code edits:

| § | What got locked |
|---|---|
| §1 | CLI surface: three flags (`--json`, `--filter-mode`, `--filter-id`); union semantics across filter kinds; no negation, no list flag |
| §2 | JSON envelope schema + manifest-error envelope shape; `--json` suppresses ALL human output; `summary.message` carries the `"ManifestError: "` prefix in error mode |
| §3 | 8-token diagnostic taxonomy — 6 per-result tokens + 2 summary-only tokens (`no_vectors_selected`, `manifest_invalid`) |
| §4 | Filter resolution flow: unknown filter values are NOT argparse errors, they select nothing and trip `no_vectors_selected` (symmetric across mode + id) |
| §5 | Exit-code matrix preserving backward compat: missing vector file is still a per-result failure (exit 1), not a manifest error (exit 2) |
| §6 | 10-case subprocess test suite; `--manifest <tmp>/manifest.json` temp-manifest approach (since subprocess tests cannot see in-process monkeypatches) |
| §7 | 4-commit split: refactor → JSON → filters+taxonomy → tests |

## Commit-by-commit walkthrough

| Commit | Scope | Key risk |
|---|---|---|
| **Commit 1** `refactor(conformance): split runner output into Renderer protocol` | Behavior-preserving extract. New `Renderer` Protocol + `HumanRenderer` (body lifted verbatim from `RunnerReport.format_summary`). `RunnerReport.format_summary` kept as a delegating compatibility shim. ManifestError handling stays on `main()`. | None — pre-save + post-save SHA byte-identical verification gate |
| **Commit 2** `feat(conformance): add --json output mode` | New `JsonRenderer` + `--json` flag + manifest-error envelope. ManifestError now routes through the renderer (stderr in human mode, stdout in JSON mode). `results[].reason_code` deferred to commit 3 (documented in the JsonRenderer docstring). | Mid — JSON contract correctness; verified against 14-sub-check envelope test |
| **Commit 3** `feat(conformance): add --filter-mode / --filter-id with diagnostic taxonomy` | The bulk of the work. New `Selection` dataclass + `selection`/`diagnostic`/`message`/`failed_count`/`exit_code` on `RunnerReport`. ~52 failure construction sites now carry an explicit `reason_code=` keyword. New `_apply_filters` helper. Defensive guards added per review: core proposal type guard, vector root type guard, JsonRenderer defensive fallbacks for reason_code AND message. | Medium-high — touches every failure site in `run.py`; verified by 19-gate / 107-sub-check post-save sweep |
| **Commit 4** `test(conformance): add runner CLI test suite` | New `tests/test_conformance_runner.py` — 10 subprocess-based pytest cases lifted 1:1 from design checkpoint §6. Includes `_run_json` helper enforcing the no-mixed-output contract on every JSON invocation. 60-second subprocess timeout protects CI from a hung runner. | Low — pure test addition |

Per-commit verification gate ran at each save boundary. No commit was committed without:
- Default-invocation SHA still matching `0E1BD60BF0E6413F88937433BB0B130A153E570487B69C723E4220D9CA8EEA01`
- `ruff check` + `ruff format --check` clean
- `git diff --stat` showing only the expected file(s)

## What's in the JSON envelope

Normal-run shape (commit 2 introduces, commit 3 fills out):

```json
{
  "manifest_version": "conformance/v0.1",
  "selection": {
    "total_in_manifest": 51,
    "selected": 51,
    "filter_modes": [],
    "filter_ids": []
  },
  "results": [
    {
      "id": "canon-001-basic-object",
      "mode": "canonicalization",
      "passed": true,
      "reason_code": null,
      "message": null
    }
  ],
  "summary": {
    "total": 51,
    "passed": 51,
    "failed": 0,
    "all_passed": true,
    "diagnostic": null,
    "message": null
  },
  "exit_code": 0
}
```

Manifest-error envelope (per design checkpoint §2 lock):

```json
{
  "manifest_version": null,
  "selection": {"total_in_manifest": 0, "selected": 0, "filter_modes": [], "filter_ids": []},
  "results": [],
  "summary": {
    "total": 0,
    "passed": 0,
    "failed": 0,
    "all_passed": false,
    "diagnostic": "manifest_invalid",
    "message": "ManifestError: manifest not found: <path>"
  },
  "exit_code": 2
}
```

`no_vectors_selected` envelope (filter selects 0):

```json
{
  "selection": {"total_in_manifest": 51, "selected": 0, "filter_modes": ["evidance"], "filter_ids": []},
  "results": [],
  "summary": {
    "all_passed": false,
    "diagnostic": "no_vectors_selected",
    "message": "filter selected zero vectors (filter_modes=['evidance'], filter_ids=[])"
  },
  "exit_code": 2
}
```

## Diagnostic taxonomy (8 tokens, design checkpoint §3 lock)

| Token | Scope | Meaning |
|---|---|---|
| `verdict_mismatch` | per-result | Verifier returned allow/block different from `expected` |
| `error_code_mismatch` | per-result | Block verdict matched but error code differed |
| `canonicalization_mismatch` | per-result | Canonical bytes or canonical SHA-256 mismatch |
| `manifest_drift` | per-result | Manifest valid but points at wrong/missing file or inline drift |
| `vector_invalid` | per-result | Vector file violates runner/vector guard shape (missing options, wrong types, forbidden `embedded_keyring`, sig evidence in trust_sanitization, bad `evidence_root_dir`, `PipelineOptions` construction failure, etc.) |
| `runner_error` | per-result | Uncaught exception at dispatch boundary (`canonicalize()` or `verify_proposal()` raised) |
| `no_vectors_selected` | summary-only | `--filter-mode` / `--filter-id` selected zero vectors |
| `manifest_invalid` | summary-only | Manifest parse / schema / entry validation failed before vector execution |

The split between per-result and summary-only is the key design move — per-result tokens describe a single vector outcome; summary-only tokens describe whole-run conditions where there are no per-vector results to tag.

`runner_error` ends up narrow in practice (only `canonicalize()` / `verify_proposal()` raises) because `PipelineOptions` construction failures were re-categorized to `vector_invalid` during review — those are vector authoring problems, not runner crashes.

## Defensive guards added during review

PR review surfaced 5 additional defensive guards that landed in commit 3:

1. **Core mode non-dict proposal guard** — parallels the existing evidence/trust_sanitization guards. Without this, a vector with `proposal: []` would leak `AttributeError: 'list' object has no attribute 'get'`.
2. **Vector root non-dict guard in `run_manifest`** — vector files containing `[]`, `"x"`, or `123` previously crashed at `vec.get("id")`; now produce a clean `vector_invalid` result.
3. **JsonRenderer defensive `reason_code` fallback** — any failing vector reaching the renderer without an explicit token defaults to `runner_error` rather than emitting schema-violating `null`.
4. **JsonRenderer defensive `message` fallback** — same shape: defaults to `"failed without message"` rather than `null`.
5. **`PipelineOptions` construction re-categorization** — moved from `runner_error` to `vector_invalid` per the review observation that bad options is an authoring problem, not a runner crash.

All five caught regressions that would otherwise have shipped quietly.

## Backward compatibility

- **`python -m conformance.run` with no args**: byte-identical stdout to v0.8.2 PR V8.2-2 (SHA verified at every commit boundary).
- **`python -m conformance.run --manifest <path>`**: unchanged behavior.
- **`python -m conformance.run --verbose`**: unchanged behavior (no-op under `--json`).
- **`python -m conformance.run --manifest <bad>` (no `--json`)**: still prints `"ManifestError: <e>"` to stderr and exits 2 — byte-identical to PR V8.2-2.
- **Vector file missing or invalid JSON**: still exit 1 (per-result `manifest_drift` / `vector_invalid`), NOT exit 2. Design checkpoint §5 explicitly locked this to preserve the pre-existing distinction between "manifest itself broken" (exit 2) and "manifest valid but a vector failed" (exit 1).
- **`RunnerReport.format_summary()`**: preserved as a delegating compatibility shim that returns `HumanRenderer().render_report(self, verbose=verbose)`. Any external caller importing `RunnerReport` keeps working.

## Test plan

- [x] `pytest tests/test_conformance_runner.py -v` → 10/10 PASS in <6s
- [x] `pytest tests/` (full suite, 258 tests) → all pass; no regressions
- [x] `python -m conformance.run` → 51/51 passed, exit 0, byte-identical SHA preserved
- [x] `python -m conformance.run --json` → valid JSON, schema matches §2 lock
- [x] `python -m conformance.run --json --filter-mode evidence` → only evidence vectors selected, all pass
- [x] `python -m conformance.run --json --filter-id DOES_NOT_EXIST` → exit 2, `summary.diagnostic="no_vectors_selected"`
- [x] `python -m conformance.run --json --manifest <bad>` → exit 2, `summary.diagnostic="manifest_invalid"`, `summary.message` prefixed `"ManifestError: "`
- [x] `python -m conformance.run --manifest <bad>` (human) → stderr `"ManifestError: <e>"`, exit 2 (byte-identical to PR V8.2-2)
- [x] `ruff check conformance/run.py tests/test_conformance_runner.py` → clean
- [x] `ruff format --check conformance/run.py tests/test_conformance_runner.py` → clean
- [x] Both CI workflows green on every commit of this branch

## Out of scope (intentionally deferred)

- **`docs/ERRORS.md` formalization** — v0.9.0. The 8-token diagnostic taxonomy here is the foundation, but ERRORS.md formal taxonomy work was excluded from v0.8.2 per the user-locked release scope.
- **`--filter-out` / negation flags** — not in v0.8.2; can be added when an operator concretely needs it.
- **`--list` (dry-run print) flag** — same.
- **TS verifier first pass** — v0.9.0; uses this runner as its conformance gate.
- **Producer-side helpers for vector authors** — v0.9.0+ work; the runner is the consumer surface.

## Reviewer guidance

- **Per-commit review is the cheap path.** The 4 commits are deliberately ordered behavior-preserving-refactor → feature-addition → bulk-refactor → tests. Reviewing in order is `Renderer seam → --json mode → filters + taxonomy → test suite`.
- **The byte-identical default-invocation SHA is the most important invariant.** It's verified at every commit save boundary in the local gate; CI runs the conformance suite which would catch any regression. If you want to spot-check, the baseline SHA is `0E1BD60BF0E6413F88937433BB0B130A153E570487B69C723E4220D9CA8EEA01` against PowerShell-redirected stdout (`python -m conformance.run 1> out.txt; Get-FileHash out.txt`).
- **The diagnostic taxonomy is closed by design.** Adding a new token requires a future PR. The 8 tokens are listed in `DC_*` constants near the top of `run.py` with explanatory comments.
- **Tests are subprocess-based**, not in-process, so they exercise argparse + exit codes + stdout/stderr routing — the real CLI surface. `_run_json` helper enforces the `--json` no-mixed-output contract on every JSON test.

## Diff stat

```
 conformance/run.py               | 752 +++++++++++++++++++++++++++++++++++++--
 tests/test_conformance_runner.py | 392 ++++++++++++++++++++
 2 files changed, 1115 insertions(+), 29 deletions(-)
```

Branch tip: `8a8d5f27` (commit 4). All 4 commits on the branch:

```
8a8d5f27 test(conformance): add runner CLI test suite
34bb2cb4 feat(conformance): add --filter-mode / --filter-id with diagnostic taxonomy
326365e9 feat(conformance): add --json output mode
31ce9a64 refactor(conformance): split runner output into Renderer protocol
```
