### PR TITLE
docs(spec): add DRAFT spec-core.md + spec-evidence.md (v0.8.2 PR 4)

### DIFF
--- a/docs/spec-core.md
+++ b/docs/spec-core.md
@@ -1,0 +1,706 @@
+# PIC Core Verifier Semantics — DRAFT
+
+> **Status:** DRAFT — v0.8.2 snapshot of PIC/1.0 core verifier
+> semantics. Not final-normative until PIC v1.0.
+> Published for community feedback per ROADMAP §1.3.
+>
+> **What this DRAFT does:** restates the normative core verifier
+> semantics that were previously scattered across
+> [RFC-0001](RFC-0001-pic-standard.md) (Core Claims, Security
+> Properties, Conformance Levels, Impact Taxonomy, Verification Rule),
+> [`causal_logic.md`](causal_logic.md) (causal taint formalization),
+> [`migration-trust-sanitization.md`](migration-trust-sanitization.md)
+> (trust axiom + sanitization timeline), and the `pic_standard.verifier`
+> + `pic_standard.pipeline` reference implementations, into a single
+> implementer-facing reference using BCP 14 language.
+>
+> **What is still open:** see Appendix C ("Open Questions Registry")
+> for IDed open questions tracked through DRAFT → final cleanup. DRAFT
+> text uses proposed normative language to preview intended Phase 1.3
+> semantics; these requirements are not binding until the specification
+> is formally adopted.
+>
+> **Cross-references:** This DRAFT CITES frozen normative artifacts
+> ([RFC-0001](RFC-0001-pic-standard.md) anchor) and companion
+> specification-track documents
+> ([`spec-evidence.md`](spec-evidence.md)) rather than restating their
+> normative content. Where a future PIC revision changes the cited
+> contract, this DRAFT will be updated in the same release. Conflicts
+> are resolved per §14 ("Normative Precedence and Conflict
+> Resolution"), not by silent re-interpretation.
+
+---
+
+## 1. Conventions
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**,
+**SHALL NOT**, **SHOULD**, **SHOULD NOT**, **RECOMMENDED**, **MAY**,
+and **OPTIONAL** in this document are to be interpreted as described
+in [BCP 14](https://www.rfc-editor.org/info/bcp14) ([RFC 2119](https://www.rfc-editor.org/rfc/rfc2119),
+[RFC 8174](https://www.rfc-editor.org/rfc/rfc8174)) when, and only
+when, they appear in all capitals, as shown here.
+
+All protocol rules in this document are **Normative**. Sections,
+blocks, and subsections explicitly labeled "Example", "Rationale",
+"Migration Note", or "Implementation Note" are **Informative** and
+do not impose conformance requirements.
+
+---
+
+## 2. Scope & Conformance Profiles
+
+This specification cites
+[`RFC-0001 §Conformance Levels`](RFC-0001-pic-standard.md#conformance-levels)
+as the historical anchor and decouples it into three named profiles
+that an implementation MUST self-declare. The two profiles defined
+by this specification family are:
+
+- **`PIC-Core`** — Action Proposal parsing, impact taxonomy, trust
+  sanitization, tool binding, verifier outcomes. Passes
+  `conformance/core/` and `conformance/trust_sanitization/`. Defined
+  normatively in this specification.
+- **`PIC-Evidence`** — evidence object parsing, hash verification,
+  signature verification, key lifecycle handling, trust upgrade.
+  Passes `conformance/evidence/`. Defined normatively in
+  [`spec-evidence.md`](spec-evidence.md).
+- **`PIC-Full`** — both `PIC-Core` and `PIC-Evidence`.
+
+An implementation MUST state which profile(s) it implements. An
+implementation MUST NOT claim `PIC-Full` unless it satisfies both
+`PIC-Core` and `PIC-Evidence`.
+
+A conformance claim MUST identify both the profile name and the
+specification snapshot/version being claimed, for example
+`PIC-Core / v0.8.2 DRAFT`, `PIC-Evidence / v0.8.2 DRAFT`, or
+`PIC-Full / v1.0` once PIC v1.0 is finalized. A claim to a DRAFT
+profile MUST NOT be represented as final PIC v1.0 conformance.
+
+`PIC-Core` MAY be deployed independently of a standalone
+`PIC-Evidence` implementation. However, this repository's
+`conformance/trust_sanitization/` suite includes evidence-backed
+matrix cells. An implementation claiming `PIC-Core` conformance
+against this repository MUST produce the expected outcomes for
+those cells, either by implementing the required
+evidence-verification behavior itself or by delegating to a
+`PIC-Evidence`-compatible component. `PIC-Core` does not require
+a standalone evidence API or signature-evidence conformance unless
+the implementation also claims `PIC-Evidence`.
+
+A `PIC-Core` implementation that does not implement `PIC-Evidence`
+MUST NOT mark evidence entries as verified and MUST NOT perform
+evidence-driven trust upgrade itself unless it implements the
+relevant `PIC-Evidence` rules or delegates to a component that
+does.
+
+---
+
+## 3. Unknown Fields and Extensions
+
+Unknown fields in protocol objects MUST be handled according to the
+active JSON Schema and profile-specific rules. Implementations MUST
+NOT silently interpret unknown fields as security-relevant
+authorization, trust, policy, evidence, or tool-binding data unless
+those fields are defined by a versioned PIC specification.
+
+Future extension fields SHOULD use a reserved extension namespace
+such as `x_` or `extensions`, but extension data MUST NOT affect
+verifier allow/block decisions unless the implementation explicitly
+opts into the corresponding extension specification.
+
+This rule applies uniformly to Action Proposals (§4), provenance
+entries (§6), claims (§4), action objects (§4), and evidence
+entries (per [`spec-evidence.md §3`](spec-evidence.md#3-unknown-fields-and-extensions)).
+
+---
+
+## 4. Action Proposal Wire Format
+
+An Action Proposal is a JSON object conforming to the PIC/1.0 JSON
+Schema (`sdk-python/pic_standard/schemas/proposal_schema.json`). Its
+required and optional fields are defined in
+[`RFC-0001 §Protocol Summary`](RFC-0001-pic-standard.md#protocol-summary-pic10-action-proposal):
+
+| Field | Type | Presence | Source of normative content |
+|---|---|---|---|
+| `protocol` | string (const `"PIC/1.0"`) | MUST | [RFC-0001 §Required Fields](RFC-0001-pic-standard.md#required-fields) |
+| `intent` | string | MUST | RFC-0001 §Required Fields |
+| `impact` | enum (see §5) | MUST | RFC-0001 §Impact Taxonomy |
+| `provenance` | array of `{id, trust, source?}` | MUST | RFC-0001 §Required Fields + §6 of this DRAFT |
+| `claims` | array of `{text, evidence[]}` | MUST | RFC-0001 §Required Fields |
+| `action` | object `{tool, args}` | MUST | RFC-0001 §Required Fields + §7 of this DRAFT |
+| `evidence` | array of evidence entries | OPTIONAL | [`spec-evidence.md §4`](spec-evidence.md#4-evidence-object-format) |
+
+Implementations MUST validate every Action Proposal against the
+PIC/1.0 JSON Schema before any other verifier rule is applied. A
+schema-validation failure MUST result in the action being blocked
+with `PIC_SCHEMA_INVALID` (see §9).
+
+This specification does NOT redefine the wire-format field set; it
+restates the validation discipline in BCP 14 language. The
+authoritative wire format is the JSON Schema artifact whose SHA-256
+fingerprint is anchored in
+[`RFC-0001 §Spec Fingerprint`](RFC-0001-pic-standard.md#spec-fingerprint).
+
+---
+
+## 5. Impact Taxonomy & Causal Taint
+
+### 5.1 Impact taxonomy
+
+The PIC/1.0 impact taxonomy is the closed enum defined in
+[`RFC-0001 §Impact Taxonomy`](RFC-0001-pic-standard.md#impact-taxonomy):
+
+| Class | Risk Level | Evidence Requirement (per RFC-0001) |
+|---|---|---|
+| `read` | Low | Untrusted provenance allowed |
+| `write` | Low | Untrusted provenance allowed |
+| `external` | Low | Untrusted provenance allowed |
+| `compute` | Low | Untrusted provenance allowed |
+| `money` | **High** | Trusted evidence required |
+| `privacy` | **High** | Trusted evidence required |
+| `irreversible` | **High** | Trusted evidence required (multi-source RECOMMENDED) |
+
+Implementations MUST reject proposals carrying an `impact` value
+outside this enum with `PIC_SCHEMA_INVALID` (the schema enforces
+the closed enum).
+
+### 5.2 Causal taint
+
+Per [`causal_logic.md`](causal_logic.md), PIC's causal-taint axiom
+is:
+
+> Any plan generated by an LLM that relies solely on Tainted data is
+> itself Tainted. Executing a High-Impact Action (money / privacy /
+> irreversible) using a Tainted plan is a Violation.
+
+Where "Tainted" data is data originating from `untrusted` provenance,
+and "Untrusted" is the trust level on provenance entries before any
+evidence-driven trust upgrade (§6.2).
+
+Normatively, for any Action Proposal whose `impact` is in
+`{money, privacy, irreversible}`:
+
+- at least one entry in `claims[].evidence[]` MUST contain an ID
+  matching a `provenance[].id` whose effective trust level (§6.4)
+  is `trusted`;
+- if no such causal chain exists, the verifier MUST reject the
+  proposal with `PIC_VERIFIER_FAILED` (see §9).
+
+When a matching `evidence[].id` is successfully verified by
+`PIC-Evidence`, it MAY upgrade the corresponding `provenance[].id`
+to effective `trusted` status for the current verification only
+(see [`spec-evidence.md §8`](spec-evidence.md#8-trust-upgrade-rules)).
+
+The causal-taint check is an ID-binding and trust-level check. It
+does NOT require the verifier to determine whether `claims[].text`
+is factually true, semantically sufficient, or complete. Natural
+language claim evaluation is outside the `PIC-Core` protocol
+boundary unless a future profile defines machine-checkable claim
+semantics.
+
+**Rationale (Informative).** Causal taint prevents prompt-injection
+attacks (T1) and hallucination-to-financial-loss attacks (T2) in
+[`RFC-0001 §Threat Model`](RFC-0001-pic-standard.md#threat-model)
+from triggering high-impact actions without verifiable evidence.
+
+---
+
+## 6. Provenance & Trust Model
+
+### 6.1 Provenance entry format
+
+Each `provenance[]` entry is an object with:
+
+- `id` (string, MUST) — stable identifier, used for ID binding with
+  `claims[].evidence[]` and `evidence[].id` per
+  [`RFC-0001 §ID Binding Convention`](RFC-0001-pic-standard.md#id-binding-convention).
+- `trust` (enum, MUST) — stable PIC/1.0 trust values are
+  `"trusted"` and `"untrusted"`. The legacy value `"semi_trusted"`
+  is deprecated and exists only during the v0.8.x transition; it
+  MUST NOT be assigned distinct protocol semantics. Implementations
+  MUST handle it according to the migration timeline in Appendix A.
+- `source` (string, OPTIONAL) — human-readable origin descriptor;
+  Informative.
+
+### 6.2 ID binding for trust upgrade
+
+Per [`RFC-0001 §ID Binding Convention`](RFC-0001-pic-standard.md#id-binding-convention),
+evidence IDs SHOULD be stable identifiers reused across `provenance`,
+`claims`, and `evidence` objects. The binding works as follows:
+
+1. `provenance[].id` identifies an input source and its initial
+   trust level.
+2. `claims[].evidence[]` references provenance IDs supporting the
+   claim.
+3. `evidence[].id` matches a provenance ID; successful verification
+   ([`spec-evidence.md §5`](spec-evidence.md#5-hash-evidence-verification)
+   or [§6](spec-evidence.md#6-signature-evidence-verification))
+   upgrades that provenance entry's effective trust (§6.4) to
+   `trusted` for the duration of the current verification.
+
+Implementations MUST apply the trust upgrade BEFORE the causal-taint
+check (§5.2) so that successful evidence verification can bridge an
+otherwise untrusted provenance into satisfying the gating rule.
+
+### 6.3 Trust as output, not input
+
+Per [`RFC-0001 §Security Properties #5`](RFC-0001-pic-standard.md#security-properties),
+trust is an *output* of cryptographic verification, not an *input*
+assumption. Under `strict_trust=True` (§10), self-asserted
+`trust="trusted"` on inbound provenance is sanitized to `untrusted`
+before any verifier rule runs; only successful evidence verification
+can subsequently upgrade it back to `trusted`.
+
+### 6.4 Effective trust
+
+"Effective trust" is the trust value used by the verifier after all
+applicable normalization, sanitization, and evidence-driven upgrades
+for the current proposal verification.
+
+Effective trust is computed in this order:
+
+1. parse and normalize provenance trust values according to the
+   active schema and migration rules;
+2. apply trust sanitization when `strict_trust=True` (§10);
+3. apply successful evidence-driven trust upgrades from
+   `PIC-Evidence` (§6.2 and
+   [`spec-evidence.md §8`](spec-evidence.md#8-trust-upgrade-rules)).
+
+Effective trust is scoped to the current verification only. It MUST
+NOT be persisted back into the proposal, cached across proposals,
+or treated as a durable reputation signal.
+
+---
+
+## 7. Tool-Binding Integrity
+
+Per [`RFC-0001 §Security Properties #3`](RFC-0001-pic-standard.md#security-properties),
+the proposal's declared `action.tool` MUST match the actual tool
+being invoked at the dispatch site. The verifier API surfaces this
+via an `expected_tool` option (or equivalent integration-level
+binding):
+
+- when the verifier is called with an `expected_tool` value, it
+  MUST compare `expected_tool` against `proposal.action.tool` using
+  exact string equality after JSON parsing. Implementations MUST NOT
+  apply case-folding, Unicode normalization, alias expansion, prefix
+  matching, or tool-name rewriting when enforcing tool binding.
+- on mismatch, the verifier MUST reject the proposal with
+  `PIC_TOOL_BINDING_MISMATCH` (see §9);
+- when no `expected_tool` is configured, tool-binding integrity is
+  the caller's responsibility and the verifier does not enforce
+  this rule.
+
+**Rationale (Informative).** Tool-binding integrity prevents the
+"agent proposed one action but attempted another" failure mode —
+e.g., a proposal declaring `action.tool="docs_search"` being used
+to dispatch `payments_send`. Without this check, an attacker could
+craft a low-impact proposal and reuse it to authorize a high-impact
+call.
+
+---
+
+## 8. Verifier Rules
+
+The verifier MUST enforce the following fail-closed checks. This
+section specifies required invariants, not a total execution order,
+except where order is security-relevant and stated explicitly.
+
+Implementations MAY enforce DoS-hardening limits before or during
+any step below. A limit breach MUST fail closed with
+`PIC_LIMIT_EXCEEDED`.
+
+Required invariants:
+
+- **Schema validation** (§4). Implementations MUST validate every
+  Action Proposal against the PIC/1.0 JSON Schema and reject schema
+  failures with `PIC_SCHEMA_INVALID`.
+- **Trust sanitization** (§10), when `strict_trust=True`.
+- **Evidence-driven trust upgrade**, delegated to `PIC-Evidence`
+  (per [`spec-evidence.md §8`](spec-evidence.md#8-trust-upgrade-rules))
+  when applicable per policy and the proposal's evidence array.
+- **Causal-taint check** (§5.2). High-impact proposals lacking a
+  trusted-evidence causal chain MUST be rejected with
+  `PIC_VERIFIER_FAILED`.
+- **Tool-binding check** (§7), when `expected_tool` is configured.
+  Mismatch MUST be rejected with `PIC_TOOL_BINDING_MISMATCH`.
+
+Order constraints that are security-relevant and MUST be honored:
+
+- Trust sanitization MUST run before evidence-driven trust upgrade.
+- Evidence-driven trust upgrade MUST run before the causal-taint
+  check.
+- Tool-binding MUST be checked before dispatching the actual tool.
+
+Any check's failure produces a fail-closed outcome
+([`RFC-0001 §Security Properties #1`](RFC-0001-pic-standard.md#security-properties));
+there is no fallback to "allow anyway."
+
+**Implementation Note (Informative).** The reference implementation
+in `sdk-python/pic_standard/pipeline.py` applies these checks in a
+specific order that satisfies all the above constraints. Other
+implementations MAY choose a different order so long as the
+security-relevant ordering constraints are preserved.
+
+---
+
+## 9. Verifier Outcomes
+
+### 9.1 Error Code Stability
+
+The error code identifiers defined in
+`sdk-python/pic_standard/errors.py` (and mirrored in
+`integrations/openclaw/lib/types.ts`) are the **portable error-code
+namespace** for PIC implementations. When a conforming implementation
+reports a failure covered by one of the semantics below, it MUST
+emit the corresponding identifier and MUST NOT substitute
+implementation-local or message-text-only identifiers. Reserved
+identifiers are listed for compatibility but are not required to be
+emitted unless their stated semantics are implemented.
+
+Codes relevant to this specification, with verified emission
+semantics from the v0.8.2 reference implementation:
+
+- `PIC_SCHEMA_INVALID` — PIC/1.0 JSON Schema validation failure on
+  the proposal envelope. Emitted by the schema-validation invariant
+  in §8.
+- `PIC_VERIFIER_FAILED` — Action Proposal structural/model-construction
+  failure after schema validation OR causal-rule rejection
+  (high-impact action lacks the required trusted-evidence causal
+  chain; under `strict_trust=True`, self-asserted trusted provenance
+  sanitized to untrusted causes a high-impact proposal to fail this
+  rule). Single emission site in the reference implementation;
+  broad scope.
+
+  **Implementation Note (Informative):** the Python reference
+  implementation uses pydantic for the model-construction step.
+
+- `PIC_TOOL_BINDING_MISMATCH` — declared `action.tool` does not
+  match the `expected_tool` configured at the verification call
+  site. Emitted by the tool-binding invariant in §8.
+- `PIC_INVALID_REQUEST` — request shape malformed before
+  verification can begin. Emitted by guard/bridge layers (MCP guard,
+  HTTP bridge) when the request envelope itself is invalid (missing
+  `__pic` argument when policy required it, proposal not a JSON
+  object, malformed/non-JSON body). NOT emitted by the verifier
+  core.
+- `PIC_LIMIT_EXCEEDED` — DoS-hardening limit breached (proposal
+  size cap, item-count caps on `provenance`/`claims`/`evidence`,
+  evaluation time budget, tool execution timeout). Emitted by the
+  DoS-hardening enforcement described in §8.
+- `PIC_INTERNAL_ERROR` — unexpected exception caught at the pipeline
+  or integration boundary. Defensive catch-all.
+- `PIC_POLICY_VIOLATION` — **Reserved.** Defined in the enum and
+  TypeScript mirror for backward compatibility with earlier PIC
+  versions. The current Python reference implementation does NOT
+  emit this code; policy-rule rejections are reported as
+  `PIC_VERIFIER_FAILED` (see CHANGELOG v0.6.x). Implementations
+  MUST NOT rely on receiving this code from the reference verifier;
+  they MAY emit it themselves for distinct policy-rule rejection
+  paths if their architecture separates "policy" from "verifier."
+
+The freeform human-readable messages accompanying each error code
+are **Informative**. They MAY vary across implementations, language
+runtimes, and locales without affecting conformance. Programmatic
+consumers (CI gates, dashboards, cross-implementation parity tests)
+MUST pattern-match on the error code, NOT on the message text.
+
+Adding a new error code is a versioned change. Removing or renaming
+an existing code is a backward-incompatible change and MUST go
+through the same governance as a wire-format change (see §13).
+Repurposing an existing code's semantics is also a
+backward-incompatible change.
+
+### 9.2 Error Code Precedence
+
+When multiple failures are present, implementations SHOULD emit the
+most specific error code whose preconditions are satisfied and
+whose behavior is pinned by conformance vectors. Where precedence
+is not explicitly specified by this DRAFT or by conformance
+vectors, implementations MUST NOT claim cross-implementation
+equivalence for that edge case.
+
+The conformance vectors pin precedence only for the cases they
+cover. This DRAFT intentionally does not define a total ordering
+for every possible multi-failure proposal. Edge cases where
+multiple independent rules fail in a single proposal fall under
+`OQ-CORE-001`.
+
+---
+
+## 10. Trust Axiom & Sanitization
+
+### 10.1 The Trust Axiom (v0.7.5+)
+
+Per [`RFC-0001 §Core Claims #6`](RFC-0001-pic-standard.md#core-claims)
+and [`migration-trust-sanitization.md`](migration-trust-sanitization.md):
+
+> Trust is verifier-derived, not producer-asserted. The only
+> conformant path from `untrusted` to `trusted` is successful
+> evidence verification.
+
+This axiom is enforced behaviorally via the `strict_trust` option:
+
+- when `strict_trust=False` (legacy, current default), the verifier
+  accepts inbound `provenance[].trust` values at face value. An
+  implementation SHOULD surface an operator-visible migration signal
+  when self-asserted `trust="trusted"` is present and effective
+  evidence verification will not run for the proposal. The Python
+  reference implementation emits `PICTrustFutureWarning`; warning
+  class names are implementation-specific and Informative.
+- when `strict_trust=True`, the verifier sanitizes all inbound
+  `provenance[].trust` values from `"trusted"` to `"untrusted"`
+  before evidence-driven trust upgrade and before the causal-taint
+  check.
+
+### 10.2 Sanitization mechanics
+
+Under `strict_trust=True`, implementations MUST:
+
+1. iterate the `provenance` array;
+2. for each entry whose `trust` value is `"trusted"`, replace the
+   in-memory value with `"untrusted"`;
+3. apply the sanitization BEFORE evidence-driven trust upgrade
+   (§6.2), so that evidence verification is the only mechanism by
+   which a provenance entry can reach effective `"trusted"` status
+   (§6.4).
+
+Sanitization is in-memory and applies only to the current
+verification; the on-the-wire proposal is not modified.
+
+### 10.3 Timeline
+
+The trust-axiom rollout is documented normatively in
+[`migration-trust-sanitization.md §Timeline`](migration-trust-sanitization.md#timeline):
+
+| Version | Behavior |
+|---|---|
+| v0.7.x | Inbound trust accepted at face value; no warnings. |
+| v0.8.0 | `PICTrustFutureWarning` emitted; `strict_trust` option added (default `False`). |
+| v0.8.1 | `PICSemiTrustedDeprecationWarning` for `trust="semi_trusted"`; value normalized to `"untrusted"` at model-validation boundary. |
+| v0.9.0 (planned) | `"semi_trusted"` removed from the schema enum. |
+| v1.0 (planned) | `strict_trust=True` is the default and the only conformant mode. Non-sanitizing mode is explicitly legacy and non-conformant. |
+
+Implementations targeting PIC v1.0 SHOULD enable `strict_trust=True`
+in advance to surface migration issues before the default flip.
+
+---
+
+## 11. Policy Boundary
+
+Per [`RFC-0001 §Core Claims #5`](RFC-0001-pic-standard.md#core-claims):
+PIC enforces protocol-level rules. Operator policy decides which
+tools and impact classes require PIC proposals at all (via
+configuration analogous to `require_pic_for_impacts`), and which
+impact classes require evidence (via `require_evidence_for_impacts`).
+Policy configuration is implementation-defined.
+
+Policy engines MAY impose stricter requirements than this protocol.
+However, a policy engine MUST NOT reinterpret PIC protocol fields
+(`provenance[].trust`, `claims[].evidence[]`, `action.tool`,
+`impact`, etc.) in a way that changes their normative meaning.
+Policy MAY deny an action that PIC would otherwise allow; policy
+MUST NOT make an invalid PIC proposal valid.
+
+**Implementation Note (Informative).** A policy engine that wants
+to require a specific provenance source for high-impact actions can
+do so by adding its own pre-verifier check that inspects the
+proposal and rejects when its policy is violated. It cannot do so
+by treating an `untrusted` provenance as `trusted` for its own
+purposes — that would be a reinterpretation of the protocol field's
+meaning.
+
+---
+
+## 12. Conformance Assertions
+
+The executable contract for this specification is the set of
+conformance vectors listed below. An implementation claiming
+conformance to this DRAFT MUST produce the same pass/fail verdicts,
+expected error codes, and diagnostics for every listed vector. The
+Python runner (`python -m conformance.run`) is the current reference
+runner for this repository; non-Python implementations MAY use an
+equivalent runner, provided the selected vectors and reported
+outcomes match the reference contract.
+
+| Vector set | Path | Modes |
+|---|---|---|
+| Core verifier (allow + block) | `conformance/core/` | `core` |
+| Trust sanitization (strict × verify matrix) | `conformance/trust_sanitization/` | `trust_sanitization` |
+
+Where this DRAFT's prose and the conformance vectors disagree, the
+discrepancy MUST be resolved by updating EITHER the DRAFT or the
+vectors before a conformance claim is asserted. The discrepancy MUST
+NOT be resolved by silent re-interpretation.
+
+See Appendix B for a per-vector cross-reference mapping conformance
+vector IDs to the section of this DRAFT each one exercises.
+
+---
+
+## 13. Backward-Compatible Changes vs Breaking Changes
+
+The following changes are backward-incompatible and MUST NOT occur
+within the same stable protocol version:
+
+- removing or renaming protocol fields;
+- changing the meaning of an existing impact class;
+- changing the trust-upgrade semantics of evidence verification;
+- changing canonicalization or digest-binding rules;
+- removing or renaming error-code identifiers;
+- changing allow/block verdicts for existing conformance vectors
+  without a versioned migration note.
+
+The following changes MAY be backward-compatible if existing
+conforming implementations remain valid:
+
+- adding new optional fields;
+- adding new conformance vectors;
+- adding new stricter policy profiles;
+- adding new error-code identifiers reserved for future use.
+
+The `strict_trust=True` default flip at v1.0 (§10.3) is a
+**deliberate** backward-incompatible change documented in
+[`migration-trust-sanitization.md`](migration-trust-sanitization.md);
+the migration path is the published timeline and an
+operator-visible migration signal. The Python reference
+implementation uses `PICTrustFutureWarning`; warning class names
+are implementation-specific and Informative.
+
+---
+
+## 14. Normative Precedence and Conflict Resolution
+
+This document is DRAFT until PIC v1.0. Where its requirements
+interact with the frozen normative artifacts of PIC/1.0, the
+following precedence applies:
+
+1. [`RFC-0001-pic-standard.md`](RFC-0001-pic-standard.md) — defensive
+   publication anchor, frozen for v0.1.0–v0.5.5. Wire-format and
+   security-property requirements that originate in RFC-0001 are
+   authoritative; this DRAFT restates them in BCP 14 form but does
+   NOT override them.
+2. [`canonicalization.md`](canonicalization.md) — PIC-CJSON/1.0,
+   frozen as of v0.8.0. Byte-level serialization rules originate
+   here; this DRAFT cites them via
+   [`spec-evidence.md`](spec-evidence.md) and MUST NOT redefine
+   them.
+3. [`spec-evidence.md`](spec-evidence.md) — companion DRAFT
+   specifying `PIC-Evidence` semantics. Evidence-side requirements
+   originate there; this DRAFT cites them and adds the verifier-side
+   ordering (§8) and trust-upgrade application point (§6.2) that
+   tie evidence verification into the core verifier flow.
+4. This DRAFT — restates v0.7.5–v0.8.x post-RFC normative core
+   verifier semantics that were previously scattered across
+   `causal_logic.md`, `migration-trust-sanitization.md`, and the
+   reference implementation.
+
+If text in this DRAFT appears to conflict with a higher-precedence
+artifact, the conflict MUST be raised as an Open Question (Appendix
+C) and resolved in a subsequent revision. The DRAFT MUST NOT be
+treated as overriding higher-precedence artifacts by silent
+re-interpretation.
+
+---
+
+## Appendix A. `semi_trusted` Deprecation (Informative — Migration Note)
+
+The `provenance[].trust` enum historically included
+`"semi_trusted"`. This value is deprecated and will be removed in
+v0.9.0. The migration path is:
+
+| Version | Behavior |
+|---|---|
+| ≤ v0.8.0 | `"semi_trusted"` accepted; silently sanitized to `"untrusted"` only in `strict_trust=True` mode. |
+| v0.8.1 | `PICSemiTrustedDeprecationWarning` emitted on any `"semi_trusted"` observed; value normalized to `"untrusted"` at the `Provenance.trust` pydantic field validator, in ALL modes. Schema enum unchanged in v0.8.1. |
+| v0.9.0 (planned) | `"semi_trusted"` removed from the JSON Schema enum. Proposals carrying it fail validation with `PIC_SCHEMA_INVALID`. |
+
+Producers SHOULD migrate any remaining `"semi_trusted"` provenance
+entries to `"untrusted"` immediately. If the proposal carries
+verifiable evidence, the verifier will derive effective `"trusted"`
+status through evidence verification per §6.2. See
+[`migration-trust-sanitization.md §FAQ`](migration-trust-sanitization.md#faq)
+for the full migration guide.
+
+---
+
+## Appendix B. Conformance Vector Cross-Reference (Informative)
+
+Maps conformance vector IDs to the section(s) of this DRAFT each
+one exercises.
+
+### B.1 Core vectors (`conformance/core/`)
+
+| Vector ID | Section(s) exercised |
+|---|---|
+| `core-allow-001-read-only` | §5.1 (low-impact path), §6 |
+| `core-allow-002-trusted-money` | §5.2 (high-impact + trusted bridge), §6 |
+| `core-block-001-untrusted-money` | §5.2 (causal-taint rejection), §9.1 (`PIC_VERIFIER_FAILED`) |
+| `core-block-002-tool-binding-mismatch` | §7, §9.1 (`PIC_TOOL_BINDING_MISMATCH`) |
+
+### B.2 Trust-sanitization vectors (`conformance/trust_sanitization/`)
+
+The 24-vector matrix covers six `matrix_id` bases × four
+`(strict_trust, verify_evidence)` cells each. All exercise §10
+(trust axiom and sanitization) and §6.4 (effective trust). Block
+cells additionally exercise §9.1 (`PIC_VERIFIER_FAILED`).
+
+| `matrix_id` | Sections exercised |
+|---|---|
+| `compute_risk` | §5.1 (low-impact), §10 (all four cells allow) |
+| `read_only_query` | §5.1 (low-impact), §10 (all four cells allow) |
+| `financial_hash_ok` | §5.2 (high-impact), §6.2 (evidence-driven upgrade), §6.4 (effective trust), §10 (sanitization × verify matrix) |
+| `financial_irreversible` | §5.2 (money-impact), §10 (strict-true cells block with `PIC_VERIFIER_FAILED`) |
+| `privacy_risk` | §5.2 (privacy-impact), §10 (strict-true cells block) |
+| `robotic_action` | §5.2 (irreversible-impact), §10 (strict-true cells block) |
+
+See [`conformance/trust_sanitization/README.md`](../conformance/trust_sanitization/README.md)
+for the full matrix expansion.
+
+---
+
+## Appendix C. Open Questions Registry (Informative)
+
+The following questions are open for community feedback. Each is
+identified by a stable ID so it can be cross-referenced from issues,
+PRs, and future revisions. DRAFT → final cleanup tracks every ID
+below; resolved items move to the changelog rather than being
+silently deleted.
+
+| ID | Summary | Resolution status |
+|---|---|---|
+| OQ-CORE-001 | Complete error precedence table | Open |
+| OQ-CORE-002 | Multi-source requirement for `irreversible` impact | Open |
+| OQ-CORE-003 | Policy-engine surface naming + standardization | Open |
+
+### OQ-CORE-001 — Complete error precedence table
+
+Define a total ordering for cases where schema, evidence, verifier,
+tool-binding, and policy failures are all simultaneously possible.
+Until resolved, conformance is pinned only for the precedence cases
+covered by conformance vectors. Resolution requires authoring new
+conformance vectors that pin the ordered precedence and an
+implementation-side audit that the reference verifier emits the
+expected code at every contested junction.
+
+### OQ-CORE-002 — Multi-source requirement for `irreversible` impact
+
+[`RFC-0001 §Impact Taxonomy`](RFC-0001-pic-standard.md#impact-taxonomy)
+says `irreversible` requires "Trusted evidence required (multi-source
+recommended)" — recommended, not required. A future profile may
+elevate multi-source to a normative requirement for `irreversible`
+impact, requiring at least two distinct trusted evidence entries
+backing the proposal. Resolution requires gathering deployment
+experience on whether single-source trusted evidence for hard-stops
+(e.g., LIDAR-only emergency-shutdown signals) is acceptable.
+
+### OQ-CORE-003 — Policy-engine surface naming + standardization
+
+§11 says policy configuration is implementation-defined. A future
+profile may standardize the option names
+(`require_pic_for_impacts`, `require_evidence_for_impacts`,
+`expected_tool`, `strict_trust`, `verify_evidence`) as a portable
+configuration surface so operators can move between PIC
+implementations without rewriting policy files. Resolution requires
+agreement among reference implementation maintainers + the v0.9.0
+TypeScript verifier author.

--- a/docs/spec-evidence.md
+++ b/docs/spec-evidence.md
@@ -1,0 +1,769 @@
+# PIC Evidence Verification Semantics — DRAFT
+
+> **Status:** DRAFT — v0.8.2 snapshot of PIC/1.0 evidence verification
+> semantics. Not final-normative until PIC v1.0.
+> Published for community feedback per ROADMAP §1.4.
+>
+> **What this DRAFT does:** restates the normative evidence verification
+> semantics that were previously scattered across [RFC-0001](RFC-0001-pic-standard.md)
+> (Security Properties #5, #6, #7), [`evidence.md`](evidence.md) (operator
+> guide), [`keyring.md`](keyring.md) (key lifecycle), and the
+> `pic_standard.evidence` reference implementation, into a single
+> implementer-facing reference using BCP 14 language.
+>
+> **What is still open:** see Appendix C ("Open Questions Registry") for
+> IDed open questions tracked through DRAFT → final cleanup. DRAFT text
+> uses proposed normative language to preview intended Phase 1.4
+> semantics; these requirements are not binding until the specification
+> is formally adopted.
+>
+> **Cross-references:** This DRAFT CITES frozen normative artifacts
+> ([RFC-0001](RFC-0001-pic-standard.md) anchor,
+> [PIC Canonical JSON v1](canonicalization.md)) and the
+> [PIC Attestation Object v1](attestation-object-draft.md) DRAFT rather
+> than restating their normative content. Where a future PIC revision
+> changes the cited contract, this DRAFT will be updated in the same
+> release. Conflicts are resolved per §19 ("Normative Precedence and
+> Conflict Resolution"), not by silent re-interpretation.
+
+---
+
+## 1. Conventions
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**,
+**SHALL NOT**, **SHOULD**, **SHOULD NOT**, **RECOMMENDED**, **MAY**,
+and **OPTIONAL** in this document are to be interpreted as described
+in [BCP 14](https://www.rfc-editor.org/info/bcp14) ([RFC 2119](https://www.rfc-editor.org/rfc/rfc2119),
+[RFC 8174](https://www.rfc-editor.org/rfc/rfc8174)) when, and only
+when, they appear in all capitals, as shown here.
+
+All protocol rules in this document are **Normative**. Sections,
+blocks, and subsections explicitly labeled "Example", "Rationale",
+"Migration Note", or "Implementation Note" are **Informative** and
+do not impose conformance requirements.
+
+---
+
+## 2. Scope & Conformance Profiles
+
+This specification cites
+[`RFC-0001 §Conformance Levels`](RFC-0001-pic-standard.md#conformance-levels)
+as the historical anchor and decouples it into three named profiles
+that an implementation MUST self-declare. The two profiles defined by
+this specification family are:
+
+- **`PIC-Core`** — Action Proposal parsing, impact taxonomy, trust
+  sanitization, tool binding, verifier outcomes. Passes
+  `conformance/core/` and `conformance/trust_sanitization/`. Defined
+  normatively in [`spec-core.md`](spec-core.md).
+- **`PIC-Evidence`** — evidence object parsing, hash verification,
+  signature verification, key lifecycle handling, trust upgrade.
+  Passes `conformance/evidence/`. Defined normatively in this
+  specification.
+- **`PIC-Full`** — both `PIC-Core` and `PIC-Evidence`.
+
+An implementation MUST state which profile(s) it implements. An
+implementation MUST NOT claim `PIC-Full` unless it satisfies both
+`PIC-Core` and `PIC-Evidence`.
+
+`PIC-Evidence` MAY be implemented independently of `PIC-Core` (e.g.,
+an evidence-verification library wrapping a separate core verifier);
+in that case the library's caller is responsible for satisfying
+`PIC-Core` requirements.
+
+---
+
+## 3. Unknown Fields and Extensions
+
+Unknown fields in protocol objects MUST be handled according to the
+active JSON Schema and profile-specific rules per
+[`spec-core.md §3`](spec-core.md#3-unknown-fields-and-extensions).
+Implementations MUST NOT silently interpret unknown fields in
+evidence objects as security-relevant authorization, trust, policy,
+evidence, or tool-binding data unless those fields are defined by a
+versioned PIC specification.
+
+Future extension fields in evidence objects SHOULD use a reserved
+extension namespace such as `x_` or `extensions`, but extension data
+MUST NOT affect signature verification outcome, hash verification
+outcome, or trust upgrade decisions unless the implementation
+explicitly opts into the corresponding extension specification.
+
+---
+
+## 4. Evidence Object Format
+
+Evidence entries appear in the optional `evidence` array of an Action
+Proposal (see [`RFC-0001 §Optional Fields`](RFC-0001-pic-standard.md#optional-fields)).
+Each entry is a JSON object with the following fields:
+
+| Field | Type | Presence | Description |
+|---|---|---|---|
+| `id` | string | MUST | Stable identifier, expected to match a `provenance[].id` for trust upgrade (see §8). |
+| `type` | string | MUST | One of `"hash"` or `"sig"`. The PIC/1.0 JSON Schema defines `type` as a closed enum; unknown values are schema-rejected with `PIC_SCHEMA_INVALID`. If an implementation's schema layer is more permissive, the evidence handler MUST reject the unknown type fail-closed with `PIC_EVIDENCE_FAILED`. |
+| `ref` | string | MUST | URI referencing the artifact. `file://<path>` for hash evidence (see §5); `inline:attestation` or implementation-defined for sig evidence (see §6). |
+| `sha256` | string | MUST when `type="hash"` | 64-character lowercase hex digest of the referenced file bytes. |
+| `payload` | string | MUST when `type="sig"` | UTF-8 string carrying the bytes that were signed; in canonical-signing mode this string parses as a JSON attestation object (see §6.2). |
+| `signature` | string | MUST when `type="sig"` | Base64 (standard alphabet per [RFC 4648 §4](https://www.rfc-editor.org/rfc/rfc4648#section-4)) Ed25519 signature. URL-safe and unpadded variants are non-conformant per [`canonicalization.md §7.10`](canonicalization.md#710-base64-variant-pic-protocol-constraint-adjacent-to-canonicalization). |
+| `alg` | string | MUST when `type="sig"` | Signature algorithm identifier. v1 supports `"ed25519"` only. Implementations MUST reject unknown algorithms fail-closed. |
+| `key_id` | string | MUST when `type="sig"` | Key identifier resolved against the trusted keyring (see §9). |
+
+**Example (Informative).** Evidence entries inside a proposal:
+
+```json
+"evidence": [
+  {
+    "id": "invoice_123",
+    "type": "hash",
+    "ref": "file://invoice_123.txt",
+    "sha256": "a2e818612ae44f799be83833149cdd8a1ea750fa8d40bc8507f874f8ad488fbd"
+  },
+  {
+    "id": "approval_123",
+    "type": "sig",
+    "ref": "inline:attestation",
+    "payload": "{\"attestation_version\":\"PIC-ATT/1.0\", ...}",
+    "alg": "ed25519",
+    "signature": "<base64>",
+    "key_id": "demo_signer_v1"
+  }
+]
+```
+
+---
+
+## 5. Hash Evidence Verification
+
+For each evidence entry with `type="hash"`:
+
+1. Implementations MUST resolve `ref` per the path-resolution rule
+   in §5.1 below.
+2. Implementations MUST read the referenced file's bytes in binary
+   mode without normalization (no newline translation, no BOM
+   stripping, no transcoding) per
+   [`canonicalization.md §7.11`](canonicalization.md#711-file-hash-rules-pic-protocol-constraint-adjacent-to-canonicalization).
+3. Implementations MUST compute SHA-256 of the file bytes and compare,
+   byte-exact, against the `sha256` field's value.
+4. On match, the evidence entry is verified; the entry's `id` is
+   eligible for trust upgrade (see §8).
+5. On any failure (file not found, hash mismatch, sandbox violation,
+   size cap breach), the evidence entry MUST NOT be marked verified.
+   The verifier outcome MUST include `PIC_EVIDENCE_FAILED` (see §11).
+
+### 5.1 Path resolution and sandboxing
+
+`file://` references MUST be resolved relative to a configured
+`evidence_root_dir`. Implementations MUST reject fail-closed:
+
+- absolute paths in `ref`;
+- relative paths that escape `evidence_root_dir` via `..` traversal;
+- paths whose resolved location is outside `evidence_root_dir`;
+- files larger than the configured `max_file_bytes` (default 5 MB per
+  [`evidence.md`](evidence.md#evidence-sandboxing)).
+
+Per [RFC-0001 §Security Properties #6](RFC-0001-pic-standard.md#security-properties),
+file-based evidence MUST be sandboxed within `evidence_root_dir`.
+
+---
+
+## 6. Signature Evidence Verification
+
+For each evidence entry with `type="sig"`:
+
+1. Implementations MUST resolve `key_id` against the trusted keyring
+   per §9 (resolver protocol) and §10 (key lifecycle). A key that is
+   missing, revoked, or expired MUST NOT produce a successful evidence
+   result (see §10).
+2. Implementations MUST determine the signing mode per §6.2.
+3. Implementations MUST compute the bytes to verify per §6.3.
+4. Implementations MUST verify the Ed25519 signature against the
+   computed bytes using the resolved public key.
+5. In canonical-signing mode, implementations MUST additionally verify
+   digest binding per §6.4 before the entry is marked verified.
+6. On success, the entry's `id` is eligible for trust upgrade (see §8).
+7. On any failure (unknown algorithm, key resolution failure,
+   signature mismatch, payload too large, mode-detection violation,
+   digest-binding failure), the verifier outcome MUST include
+   `PIC_EVIDENCE_FAILED` (see §11).
+
+### 6.2 Signing Modes — Legacy and Canonical
+
+> **Note:** This subsection and §6.3, §6.4 are load-bearing for the
+> opt-in canonical attestation-object signing implementation (PIC
+> v0.8.2 PR V8.2-5).
+
+Implementations MUST detect the signing mode of each `sig` evidence
+entry from the parsed `payload`. The detection rule is a three-way
+discriminator:
+
+1. **Legacy mode.** The entry is in **legacy mode** if any of the
+   following holds:
+   - the `payload` string does not parse as JSON;
+   - the `payload` string parses as JSON but the parsed value is not
+     an object (e.g., array, string, number, boolean, or null);
+   - the `payload` string parses as a JSON object that does NOT
+     contain an `attestation_version` key.
+
+   In all these cases, bytes to verify are the raw UTF-8 bytes of
+   the `payload` string (see §6.3).
+
+2. **Canonical mode (well-formed).** If the `payload` string parses as
+   a JSON object containing a string-valued `attestation_version` AND
+   the string value is in the implementation's supported attestation
+   version allowlist, the entry is in **canonical mode**. Bytes to
+   verify are computed per §6.3 (PIC Canonical JSON v1 over the
+   parsed attestation object). Digest binding (§6.4) applies.
+
+3. **Canonical-looking but malformed or unknown.** If the `payload`
+   parses as a JSON object that contains `attestation_version` but
+   the value is non-string (number, bool, list, object, null) OR is
+   a string not in the supported allowlist, the entry MUST be
+   rejected fail-closed with `PIC_EVIDENCE_FAILED`. Implementations
+   MUST NOT silently fall back to legacy mode in this case;
+   silent fallback would be a security footgun for malformed or
+   future-version canonical-looking payloads.
+
+The intended supported attestation version allowlist for `PIC-Evidence`
+v0.8.2 is `{"PIC-ATT/1.0"}` — the version identifier specified by
+[`attestation-object-draft.md`](attestation-object-draft.md) and used
+in [`canonicalization.md §9.4`](canonicalization.md#94-attestation-object-example).
+The exact allowlist constant is locked in the reference implementation
+by PR V8.2-5 (opt-in canonical signing, see ROADMAP §1.5). Future PIC
+revisions MAY extend the allowlist; unknown versions in current
+implementations MUST fail closed per (3).
+
+**Rationale (Informative).** A binary "is canonical?" check based on
+key presence alone would let malformed canonical-looking payloads
+silently downgrade to legacy mode, where less-strict byte semantics
+might accept a forgery the canonical path would reject. The three-way
+discriminator forces an explicit, fail-closed decision on every
+`payload`.
+
+### 6.3 Canonical-Bytes Computation
+
+For evidence entries in **legacy mode** (§6.2.1), the bytes to
+verify are the raw UTF-8 bytes of the `payload` string exactly as
+they appear in the evidence entry, without canonicalization or
+normalization.
+
+For evidence entries in **canonical mode** (§6.2.2), the bytes to
+verify are computed as
+`canonicalize(parsed_attestation_object)` per
+[`canonicalization.md §8.4`](canonicalization.md#84-attestation-object-serialization).
+Implementations MUST parse the `payload` string as JSON and apply
+PIC Canonical JSON v1 (PIC-CJSON/1.0) to the parsed value;
+implementations MUST NOT sign or verify raw transport JSON bytes in
+canonical mode.
+
+**Rationale (Informative).** The strict re-canonicalization on the
+verifier side guards against lossy transport (e.g., middleware that
+re-serializes JSON, re-orders keys, normalizes whitespace, or
+roundtrips through a database that strips insignificant whitespace).
+The signature in canonical mode is always over canonical bytes,
+never over raw payload text.
+
+### 6.4 Digest Verification Post-Signature
+
+For evidence entries in **canonical mode** (§6.2.2), after the
+Ed25519 signature has verified successfully over the canonical bytes
+(§6.3), implementations MUST verify that the attestation object's
+`args_digest`, `claims_digest`, and (when present) `intent_digest`
+match the corresponding canonicalized fields of the Action Proposal:
+
+- `args_digest` MUST equal SHA-256 of `canonicalize(proposal.action.args)`
+  per [`canonicalization.md §8.1`](canonicalization.md#81-args_digest).
+- `claims_digest` MUST equal SHA-256 of `canonicalize(proposal.claims)`
+  per [`canonicalization.md §8.2`](canonicalization.md#82-claims_digest).
+- `intent_digest`, when present, MUST equal SHA-256 of the UTF-8
+  bytes of `proposal.intent` per
+  [`canonicalization.md §8.3`](canonicalization.md#83-intent_digest).
+
+Implementations MUST also verify that the attestation object's
+`tool` equals `proposal.action.tool` and that
+`provenance_ids` lists provenance entry IDs in proposal-array order.
+
+Any digest mismatch, tool mismatch, or provenance-ids ordering
+mismatch MUST cause the evidence entry to be rejected fail-closed
+with `PIC_EVIDENCE_FAILED`, even though the signature itself
+verified.
+
+**Rationale (Informative).** A valid signature over an attestation
+object whose digests do NOT match the proposal it accompanies means
+either (a) the signer attested to a different proposal than was
+delivered, or (b) the proposal was modified after signing. Both
+cases are security failures that signature verification alone does
+not catch.
+
+---
+
+## 7. Attestation Object Signing
+
+The producer-side construction and signing process for canonical-mode
+evidence is defined in
+[`attestation-object-draft.md §Signing Process`](attestation-object-draft.md#signing-process).
+This specification's normative addition is the verifier-side rule
+that re-canonicalization (§6.3) and digest verification (§6.4) are
+mandatory, fail-closed checks after signature verification in
+canonical mode.
+
+Implementations MUST follow the verifier process specified in
+[`attestation-object-draft.md §Signing Process`](attestation-object-draft.md#signing-process)
+unchanged: parse → re-canonicalize → verify signature → enforce
+semantics (mode allowlist, tool match, freshness, digest binding).
+
+---
+
+## 8. Trust Upgrade Rules
+
+Per [RFC-0001 §ID Binding Convention](RFC-0001-pic-standard.md#id-binding-convention),
+evidence verification produces trust as an *output*, not an input
+assumption. When an evidence entry's verification (hash per §5 or
+signature per §6) succeeds, implementations MUST upgrade the trust
+level of any matching `provenance[].id` entry from `"untrusted"` to
+`"trusted"` for the remainder of the verification of that proposal.
+
+The trust upgrade MUST be applied BEFORE the core verifier's causal
+gating check (high-impact actions require trusted-evidence chain) so
+that a successful evidence verification can bridge an otherwise
+untrusted provenance to satisfy the gating rule.
+
+Implementations MUST NOT persist or propagate the upgraded trust
+level beyond the scope of the current proposal verification. Trust
+upgrades are per-verification, in-memory, and do not retroactively
+affect previously-verified proposals or future proposals.
+
+**Migration Note (Informative).** v0.7.5 introduced
+`strict_trust=True` (see [`migration-trust-sanitization.md`](migration-trust-sanitization.md)
+and [`spec-core.md §10`](spec-core.md#10-trust-axiom--sanitization))
+which sanitizes self-asserted `trust="trusted"` provenance to
+`untrusted` BEFORE evidence verification runs. Under `strict_trust`,
+the only path from `untrusted` to `trusted` is successful evidence
+verification — eliminating the legacy self-assertion bypass.
+
+---
+
+## 9. Keyring & Resolver Protocol
+
+Implementations MUST resolve `key_id` values via an explicit
+key-resolution interface. The interface MUST distinguish an active
+resolved key from non-active states such as missing, revoked, or
+expired (see §10). The concrete API shape MAY vary by implementation.
+
+The reference implementation's `KeyResolver` interface is documented
+in `sdk-python/pic_standard/keyring.py`; the operator-facing keyring
+file format is documented in [`keyring.md`](keyring.md). Key encodings
+supported in v1 are base64 (recommended), hex, and PEM (the latter
+requires the `cryptography` package per [`keyring.md`](keyring.md#key-formats)).
+
+Implementations MUST NOT silently fall back to ambient sources
+(environment variables, CWD-relative files, system keychains) when
+running portable conformance vectors. Per the
+[`conformance/evidence/README.md`](../conformance/evidence/README.md)
+hermeticity contract, sig-evidence conformance vectors carry an
+explicit `embedded_keyring` field that the runner constructs into a
+`StaticKeyRingResolver`; implementations claiming `PIC-Evidence`
+conformance MUST honor that hermeticity rule.
+
+---
+
+## 10. Key Lifecycle
+
+A `key_id` is treated as inactive if any of the conditions in the
+following table holds (cf.
+[`keyring.md §Expiry & Revocation`](keyring.md#expiry--revocation)):
+
+| Condition | Status |
+|---|---|
+| `key_id` not in the keyring | `missing` |
+| `key_id` in the keyring's `revoked_keys` list | `revoked` |
+| Key carries an `expires_at` timestamp in the past | `expired` |
+| Otherwise | `ok` |
+
+Trusted keyring entries with `expires_at` in the past, or appearing
+in the keyring's `revoked_keys` list, MUST NOT produce a successful
+evidence result. Implementations MUST check expiry and revocation
+before accepting signature evidence as valid. They MAY perform
+cryptographic verification before, after, or alongside lifecycle
+checks, but a revoked or expired key MUST NOT produce a successful
+evidence result. (Per [RFC-0001 §Security Properties #7](RFC-0001-pic-standard.md#security-properties).)
+
+Implementations SHOULD distinguish `missing` / `revoked` / `expired`
+in their internal diagnostics for operator clarity (per
+[`evidence.md §Fail-closed design`](evidence.md#fail-closed-design)),
+but the externally-emitted error code is `PIC_EVIDENCE_FAILED` (see
+§11) for all three.
+
+---
+
+## 11. Evidence Error Semantics
+
+### 11.1 Error Code Stability
+
+The error code identifiers defined in
+`sdk-python/pic_standard/errors.py` (and mirrored in
+`integrations/openclaw/lib/types.ts`) are the **portable error-code
+namespace** for PIC implementations. When a conforming implementation
+reports a failure covered by one of the semantics below, it MUST
+emit the corresponding identifier and MUST NOT substitute
+implementation-local or message-text-only identifiers. Reserved
+identifiers are listed for compatibility but are not required to be
+emitted unless their stated semantics are implemented.
+
+Codes relevant to this specification, including schema-level evidence
+shape failures and evidence-verification failures, with verified
+emission semantics from the v0.8.2 reference implementation:
+
+- `PIC_SCHEMA_INVALID` — schema-level failure while parsing the
+  proposal or evidence object shape. For `PIC-Evidence`, this covers
+  malformed evidence fields that are rejected by the PIC/1.0 JSON
+  Schema before per-entry evidence verification runs, including
+  invalid digest format and closed-enum violations such as unknown
+  `evidence[].type` values. Distinct from `PIC_EVIDENCE_FAILED`,
+  which applies after evidence is present and reaches evidence
+  verification.
+- `PIC_EVIDENCE_REQUIRED` — **pipeline-level** outcome: the active
+  policy (`require_evidence_for_impacts`) requires the proposal's
+  impact class to be backed by evidence, but the proposal contains
+  no top-level `evidence` array entries to verify. Emitted before
+  any per-entry evidence verification runs. Distinct from
+  `PIC_EVIDENCE_FAILED`, which describes a per-entry verification
+  failure (evidence was present but invalid).
+- `PIC_EVIDENCE_FAILED` — evidence verification failed. Covers all
+  per-entry failure modes: hash mismatch, hash file not found,
+  signature invalid, signing key unknown/revoked/expired, signed
+  payload exceeds size cap, sandbox path traversal, mode-detection
+  violation (§6.2), digest-binding mismatch (§6.4), evidence module
+  unavailable. Pinned by `conformance/evidence/block/001-010`
+  vectors.
+
+The freeform human-readable messages accompanying each error code
+are **Informative**. They MAY vary across implementations, language
+runtimes, and locales without affecting conformance. Programmatic
+consumers (CI gates, dashboards, cross-implementation parity tests)
+MUST pattern-match on the error code, NOT on the message text.
+
+Adding a new error code is a versioned change. Removing or renaming
+an existing code is a backward-incompatible change and MUST go
+through the same governance as a wire-format change (see §18).
+Repurposing an existing code's semantics is also a
+backward-incompatible change.
+
+---
+
+## 12. Attestation Object Relationship
+
+The attestation object is the security-relevant payload carried
+inside a `sig` evidence entry's `payload` field when the entry uses
+canonical-signing mode (§6.2.2). Its structure, field set, and
+field-presence requirements are defined in
+[`attestation-object-draft.md`](attestation-object-draft.md). This
+specification adds no new attestation-object fields and changes none
+of those defined; it specifies only how verifiers consume the
+attestation object (parse, re-canonicalize, verify, digest-bind).
+
+Legacy-mode (§6.2.1) sig evidence entries carry an opaque `payload`
+string that is not an attestation object. The attestation object
+relationship applies only to canonical mode.
+
+---
+
+## 13. Canonicalization & Digest Binding
+
+PIC Canonical JSON v1 ([PIC-CJSON/1.0](canonicalization.md)) is the
+sole canonicalization profile recognized by this specification.
+Implementations MUST use it unchanged for:
+
+- the canonical bytes signed in canonical mode (§6.3, per
+  [`canonicalization.md §8.4`](canonicalization.md#84-attestation-object-serialization));
+- the digest inputs in canonical mode (§6.4, per
+  [`canonicalization.md §8.1–§8.3`](canonicalization.md#81-args_digest)).
+
+Implementations MUST NOT define an alternative canonicalization
+profile, reorder canonical bytes, or normalize Unicode prior to
+canonicalization. The rejection rules in
+[`canonicalization.md §7.1–§7.13`](canonicalization.md#71-encoding)
+apply unchanged to canonical-mode attestation objects.
+
+File-hash digest inputs (§5) use raw file bytes per
+[`canonicalization.md §7.11`](canonicalization.md#711-file-hash-rules-pic-protocol-constraint-adjacent-to-canonicalization);
+no canonicalization is applied.
+
+---
+
+## 14. Distinction: Protocol vs. Policy
+
+Per [RFC-0001 §Core Claims #5](RFC-0001-pic-standard.md#core-claims):
+PIC enforces evidence verification semantics at the protocol level.
+Operator policy decides which tools and impact classes require
+evidence at all (via configuration analogous to
+`require_evidence_for_impacts`).
+
+Policy engines MAY impose stricter requirements than this protocol.
+However, a policy engine MUST NOT reinterpret PIC protocol fields
+(`evidence[].type`, `evidence[].sha256`, `evidence[].signature`, etc.)
+in a way that changes their normative meaning. Policy MAY deny an
+action that PIC would otherwise allow; policy MUST NOT make an
+invalid PIC proposal valid.
+
+---
+
+## 15. Freshness & Replay Prevention
+
+When the canonical-mode attestation object carries `expires_at`,
+implementations MUST reject the evidence entry if the timestamp is
+in the past at verification time. Clock-skew tolerance is
+deployment-configured, not protocol-mandated (per
+[`attestation-object-draft.md §Freshness Semantics`](attestation-object-draft.md#freshness-semantics)).
+
+When the attestation object carries `issued_at`, implementations MAY
+use it for audit and freshness assessment but MUST NOT use it alone
+to gate verification outcome.
+
+Full replay prevention (nonce caches, bounded TTL registries) is
+NOT part of this specification. It is deferred to a profile-level
+mechanism; see Appendix C, `OQ-EVIDENCE-004`.
+
+---
+
+## 16. Security Considerations
+
+This section lists the security-relevant invariants enforced by
+evidence verification. Each is normative.
+
+### 16.1 Key Resolution
+
+Implementations MUST resolve verification keys via an explicit
+key-resolution interface (§9). They MUST NOT silently fall back to
+process-wide environment variables, ambient CWD-relative keyring
+files, or other implicit sources when running portable conformance
+vectors. The reference runner's hermeticity contract
+(`conformance/evidence/README.md`) enforces this by rejecting
+evidence vectors that would otherwise reach the legacy
+`PIC_KEYS_PATH` fallback.
+
+### 16.2 Hash Root Confinement
+
+File-backed hash evidence (§5) MUST be resolved against an
+explicitly configured `evidence_root_dir`. Absolute paths, paths
+escaping the configured root via `..` traversal, and paths outside
+the declared artifact subtree MUST be rejected fail-closed. The
+reference runner additionally confines `evidence_root_dir` itself to
+`conformance/artifacts/` for portable vectors.
+
+### 16.3 Signature Payload Canonicalization
+
+Signers and verifiers in canonical-signing mode (§6.2.2) MUST
+compute signed bytes from `canonicalize(parsed_attestation_object)`
+per [`canonicalization.md §8.4`](canonicalization.md#84-attestation-object-serialization).
+They MUST NOT sign or verify raw transport JSON bytes in canonical
+mode. The mode discriminator (§6.2) is the presence of a
+string-valued `attestation_version` in the parsed payload;
+non-string and unknown string values MUST fail closed.
+
+### 16.4 Revocation and Expiry
+
+Per §10. Trusted keyring entries with `expires_at` in the past or
+appearing in the keyring's `revoked_keys` list MUST NOT produce a
+successful evidence result. Implementations MUST check expiry and
+revocation before accepting signature evidence as valid. They MAY
+perform cryptographic verification before, after, or alongside
+lifecycle checks, but a revoked or expired key MUST NOT produce a
+successful evidence result.
+
+### 16.5 Sandboxed Evidence Resolution
+
+`file://` URIs in evidence entries MUST resolve only within the
+configured `evidence_root_dir`. Implementations MUST reject any
+resolved path outside that subtree fail-closed. (Per
+[RFC-0001 §Security Properties #6](RFC-0001-pic-standard.md#security-properties).)
+
+### 16.6 No Implicit Trust Upgrade
+
+Trust upgrade via evidence verification (§8) MUST be the result of
+explicit cryptographic verification, NOT a side effect of parsing or
+transport. Implementations MUST NOT mark provenance entries as
+trusted on the basis of declared `trust: "trusted"` alone when
+`strict_trust=True` is enabled (the v0.7.5 Trust Axiom; see
+[`spec-core.md §10`](spec-core.md#10-trust-axiom--sanitization)).
+
+---
+
+## 17. Conformance Assertions
+
+The executable contract for this specification is the set of
+conformance vectors listed below. An implementation claiming
+conformance to this DRAFT MUST produce the same pass/fail verdicts,
+expected error codes, and diagnostics for every listed vector. The
+Python runner (`python -m conformance.run`) is the current reference
+runner for this repository; non-Python implementations MAY use an
+equivalent runner, provided the selected vectors and reported
+outcomes match the reference contract.
+
+| Vector set | Path | Modes |
+|---|---|---|
+| Evidence (allow + block) | `conformance/evidence/` | `evidence` |
+| Canonicalization (transitive dependency for canonical-signing mode) | `conformance/canonicalization/` | `canonicalization` |
+
+Where this DRAFT's prose and the conformance vectors disagree, the
+discrepancy MUST be resolved by updating EITHER the DRAFT or the
+vectors before a conformance claim is asserted. The discrepancy MUST
+NOT be resolved by silent re-interpretation.
+
+See Appendix A for a per-vector cross-reference mapping conformance
+vector IDs to the section of this DRAFT each one exercises.
+
+---
+
+## 18. Backward-Compatible Changes vs Breaking Changes
+
+The following changes are backward-incompatible and MUST NOT occur
+within the same stable protocol version:
+
+- removing or renaming evidence-object fields;
+- changing the meaning of an existing evidence `type` value;
+- changing the trust-upgrade semantics of evidence verification;
+- changing canonicalization or digest-binding rules;
+- removing or renaming error-code identifiers in the evidence
+  namespace;
+- changing allow/block verdicts for existing conformance vectors
+  without a versioned migration note;
+- removing supported attestation-version values from the §6.2.2
+  allowlist (adding new versions is backward-compatible; removing
+  existing ones is not).
+
+The following changes MAY be backward-compatible if existing
+conforming implementations remain valid:
+
+- adding new optional evidence-object fields;
+- adding new evidence `type` values (implementations encountering
+  unknown types MUST fail closed per §4);
+- adding new conformance vectors;
+- adding new stricter policy profiles;
+- adding new attestation-version values to the supported allowlist;
+- adding new error-code identifiers reserved for future use.
+
+---
+
+## 19. Normative Precedence and Conflict Resolution
+
+This document is DRAFT until PIC v1.0. Where its requirements
+interact with the frozen normative artifacts of PIC/1.0, the
+following precedence applies:
+
+1. [`RFC-0001-pic-standard.md`](RFC-0001-pic-standard.md) — defensive
+   publication anchor, frozen for v0.1.0–v0.5.5. Wire-format and
+   security-property requirements that originate in RFC-0001 are
+   authoritative; this DRAFT restates them in BCP 14 form but does
+   NOT override them.
+2. [`canonicalization.md`](canonicalization.md) — PIC-CJSON/1.0,
+   frozen as of v0.8.0. Byte-level serialization, digest
+   computation, and attestation-object canonical-bytes rules
+   originate here; this DRAFT cites them and MUST NOT redefine them.
+3. [`attestation-object-draft.md`](attestation-object-draft.md) —
+   PIC Attestation Object v1 DRAFT. Field set and signing-process
+   semantics originate there; this DRAFT cites them and adds only
+   the verifier-side mandatory-fail-closed rules (§6.2–§6.4) on
+   top.
+4. This DRAFT — restates v0.7.5–v0.8.x post-RFC normative
+   evidence-verification semantics that were previously scattered
+   across `evidence.md`, `keyring.md`, and the reference
+   implementation.
+
+If text in this DRAFT appears to conflict with a higher-precedence
+artifact, the conflict MUST be raised as an Open Question (Appendix
+C) and resolved in a subsequent revision. The DRAFT MUST NOT be
+treated as overriding higher-precedence artifacts by silent
+re-interpretation.
+
+---
+
+## Appendix A. Conformance Vector Cross-Reference (Informative)
+
+Maps conformance vector IDs to the section(s) of this DRAFT each
+one exercises.
+
+| Vector ID | Section(s) exercised |
+|---|---|
+| `evidence-hash-allow-001-simple` | §5 |
+| `evidence-hash-allow-002-multiple-hashes` | §5 |
+| `evidence-hash-block-001-mismatch` | §5, §11 |
+| `evidence-hash-block-002-file-not-found` | §5.1, §11 |
+| `evidence-hash-block-003-invalid-sha256-format` | §4 (schema), §11 |
+| `evidence-sandbox-block-001-path-traversal` | §5.1, §16.2, §16.5 |
+| `evidence-sandbox-block-002-absolute-outside-root` | §5.1, §16.2, §16.5 |
+| `evidence-sig-allow-001-simple` | §6, §9, §10 |
+| `evidence-sig-block-001-payload-tampered` | §6, §11 |
+| `evidence-sig-block-002-unknown-key-id` | §9, §10, §11 |
+| `evidence-sig-block-003-revoked-key` | §10, §16.4, §11 |
+| `evidence-sig-block-004-expired-key` | §10, §16.4, §11 |
+| `evidence-sig-block-005-payload-too-large` | §6, §11 |
+| `evidence-mixed-allow-001-hash-and-sig` | §5, §6, §8 |
+
+Canonical-signing-mode vectors (§6.2.2, §6.3, §6.4) are scheduled
+for addition in v0.8.2 PR V8.2-5; their IDs will be added here when
+that PR lands.
+
+---
+
+## Appendix B. Backward Compat (Informative)
+
+This DRAFT does not change the wire format of `evidence` objects.
+Legacy-mode (§6.2.1) sig evidence remains valid; existing
+implementations that consume only legacy-mode sig evidence retain
+PIC/1.0 compatibility.
+
+Canonical-signing mode (§6.2.2) is identified by the presence of a
+supported string-valued `attestation_version` in the parsed
+payload. Verifiers that do not yet implement canonical mode will
+encounter such payloads as unsupported by their mode-detection
+logic; per §6.2.3, they MUST fail closed rather than fall back to
+legacy mode.
+
+See [`attestation-object-draft.md §Backward Compatibility`](attestation-object-draft.md#backward-compatibility)
+for the producer-side compatibility story.
+
+---
+
+## Appendix C. Open Questions Registry (Informative)
+
+The following questions are open for community feedback. Each is
+identified by a stable ID so it can be cross-referenced from issues,
+PRs, and future revisions. DRAFT → final cleanup tracks every ID
+below; resolved items move to the changelog rather than being
+silently deleted.
+
+| ID | Summary | Resolution status |
+|---|---|---|
+| OQ-EVIDENCE-001 | Canonical signing envelope stability | Open |
+| OQ-EVIDENCE-002 | Clock-skew tolerance protocol-level vs deployment-level | Open |
+| OQ-EVIDENCE-003 | Digest algorithm agility | Open |
+| OQ-EVIDENCE-004 | Replay-prevention profile (nonce caches, TTL registries) | Open |
+
+### OQ-EVIDENCE-001 — Canonical signing envelope stability
+
+The canonical-mode signing envelope (attestation object + signature + `key_id`) is currently carried inside the existing `sig` evidence entry shape (§4). A future profile may want to split canonical-mode evidence into its own evidence `type` (e.g., `"canonical_sig"`) to make the mode-distinction visible at the schema layer rather than at parse time. Resolution requires a backward-compatibility analysis against §18 and an authoring decision on whether to deprecate the overloaded `"sig"` type.
+
+### OQ-EVIDENCE-002 — Clock-skew tolerance protocol-level vs deployment-level
+
+§15 leaves `expires_at` clock-skew tolerance as
+deployment-configured. A protocol-level lower bound (e.g.,
+"verifiers MUST tolerate at least 60 seconds of clock skew") would
+improve cross-implementation interop for time-sensitive evidence but
+constrains deployments. Resolution requires gathering operational
+data from existing PIC deployments.
+
+### OQ-EVIDENCE-003 — Digest algorithm agility
+
+The attestation object's digests (§6.4) are currently SHA-256 only,
+inherited from [`attestation-object-draft.md`](attestation-object-draft.md#open-questions).
+A future profile may add algorithm identifiers (e.g.,
+`"args_digest_alg": "sha256"`) to permit SHA-3 or BLAKE3. Resolution
+requires deciding whether algorithm agility lives in the attestation
+object (per-field) or in a new attestation_version (whole-payload).
+
+### OQ-EVIDENCE-004 — Replay-prevention profile
+
+Full replay prevention is deferred (§15). A profile-level
+specification needs to define nonce shape, cache TTL bounds, and
+distributed-verifier coordination. Resolution requires authoring a
+separate `docs/spec-evidence-replay-profile.md`.

--- a/docs/spec-status.md
+++ b/docs/spec-status.md
@@ -16,10 +16,57 @@
 | v0.7.5 | Trust sanitization (`strict_trust`), deprecation warning for self-asserted trust, attestation object draft, migration guide | None — behavioral option only; wire format unchanged |
 | v0.8.0 | PIC Canonical JSON v1 spec (`docs/canonicalization.md`) + reference implementation (`pic_standard.canonical`), initial canonicalization + core conformance suite, conformance runner (`python -m conformance.run`), `PIC Conformance` CI job, refined attestation object draft with byte-level worked example | None — new capability added; existing proposals and signature verification paths unchanged. Canonicalization is not yet wired into evidence signing in v0.8.0. |
 | v0.8.1 | `PICSemiTrustedDeprecationWarning` for `provenance[].trust = "semi_trusted"`; canonical normalization at the model-validation boundary (pydantic field validator on `Provenance.trust`) with a bridge helper in `verify_proposal()` triggering it after JSON Schema validation; both deprecation-warning classes re-exported at package root; example files migrated off `semi_trusted`; verdict-regression matrix added as a permanent CI guard for the dict-vs-model boundary | None — schema enum unchanged in v0.8.1 (still accepts `"semi_trusted"`); runtime normalizes to `"untrusted"` at parse time. Wire format unchanged. Schema-level removal scheduled for v0.9.0. |
+| v0.8.2 | Evidence-mode conformance vectors (14 vectors under `conformance/evidence/`); trust-sanitization-mode conformance vectors (24 vectors under `conformance/trust_sanitization/` covering the `strict_trust × verify_evidence` matrix lifted from `tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX`); conformance runner hardening (`--json` output, `--filter-mode`/`--filter-id` filters, 8-token diagnostic taxonomy, manifest-error envelope, subprocess-based CLI test suite in `tests/test_conformance_runner.py`); initial DRAFT specs `docs/spec-core.md` and `docs/spec-evidence.md` defining `PIC-Core` and `PIC-Evidence` conformance profiles in BCP 14 normative language. DRAFTs not final-normative until v1.0; published for community feedback per ROADMAP §1.3/§1.4. | None — additive only. New conformance vectors, machine-readable runner output, and DRAFT specs do not change the proposal wire format or existing verifier behavior. During runner-hardening, the default-invocation conformance runner human output format was preserved byte-identically relative to the post-vector baseline; vector counts changed only because new conformance vectors were added. |
 
 The PIC/1.0 proposal structure and wire-level schema have remained stable since the RFC anchor. Post-RFC changes in v0.6.x–v0.8.x primarily affected shared pipeline behavior, trust resolution, integration surface, runtime efficiency, and canonicalization/conformance tooling rather than introducing a wire-format break.
 
 **Current Python reference implementation:** v0.8.1
+
+---
+
+## PIC/1.0 Specifications
+
+This repository hosts PIC/1.0 specification-track documents in
+addition to RFC-0001. Specifications cite RFC-0001 and the frozen
+canonicalization spec as authoritative; they restate v0.7.5+ semantics
+in BCP 14 normative language for implementer-facing reference.
+
+| Specification | Status | Profile coverage | Source |
+|---------------|--------|------------------|--------|
+| [PIC Canonical JSON v1](canonicalization.md) | Stable (frozen as of v0.8.0) | Required by `PIC-Evidence` for canonical-signing mode and attestation-object digest binding | `docs/canonicalization.md` |
+| [PIC Attestation Object v1 — Draft](attestation-object-draft.md) | DRAFT | Required by `PIC-Evidence` for canonical-signing mode (opt-in during v0.8.x; intended default before PIC v1.0 unless superseded by DRAFT resolution) | `docs/attestation-object-draft.md` |
+| [PIC Core Verifier Semantics](spec-core.md) | DRAFT (v0.8.2) | Defines `PIC-Core` profile | `docs/spec-core.md` |
+| [PIC Evidence Verification Semantics](spec-evidence.md) | DRAFT (v0.8.2) | Defines `PIC-Evidence` profile | `docs/spec-evidence.md` |
+
+### Conformance profiles
+
+Defined normatively in [`spec-core.md §2`](spec-core.md#2-scope--conformance-profiles)
+and [`spec-evidence.md §2`](spec-evidence.md#2-scope--conformance-profiles).
+Summary:
+
+- **`PIC-Core`** — Action Proposal parsing, impact taxonomy, trust
+  sanitization, tool binding, verifier outcomes. Passes
+  `conformance/core/` and `conformance/trust_sanitization/`.
+- **`PIC-Evidence`** — Evidence object parsing, hash verification,
+  signature verification, key lifecycle, trust upgrade. Passes
+  `conformance/evidence/`.
+- **`PIC-Full`** — Both `PIC-Core` and `PIC-Evidence`. An
+  implementation MUST NOT claim `PIC-Full` unless it satisfies both
+  underlying profiles.
+
+A conforming implementation MUST state which profile(s) it implements.
+
+### DRAFT status discipline
+
+DRAFT specifications are not final-normative until PIC v1.0 (per
+ROADMAP §1.3/§1.4). Open questions are tracked in each spec's
+Appendix C ("Open Questions Registry") with stable IDs (e.g.
+`OQ-CORE-001`, `OQ-EVIDENCE-001`) so they can be cross-referenced
+from issues, PRs, and future revisions. DRAFTs cite higher-precedence
+artifacts (RFC-0001, `canonicalization.md`) without restating their
+normative content; conflicts are resolved as Open Questions, not by
+silent re-interpretation (see each spec's "Normative Precedence and
+Conflict Resolution" section).
 
 ---
 


### PR DESCRIPTION
## Summary

Fourth PR of the v0.8.2 conformance campaign. Pure docs — lands the initial DRAFT specifications for the `PIC-Core` and `PIC-Evidence` conformance profiles, restating v0.7.5–v0.8.x post-RFC normative semantics into a single implementer-facing reference using BCP 14 language. Foundation for the v0.9.0 TypeScript verifier cross-implementation work.

- `docs/spec-core.md` (NEW) — 14 sections + 3 appendices defining `PIC-Core`
- `docs/spec-evidence.md` (NEW) — 19 sections + 3 appendices defining `PIC-Evidence`
- `docs/spec-status.md` (MODIFIED) — v0.8.2 changelog row + new `PIC/1.0 Specifications` section + DRAFT-status discipline

**Pure docs. No code change. No conformance vectors added.** Default-invocation runner output preserved byte-identical (SHA still `0E1BD60BF0E6413F88937433BB0B130A153E570487B69C723E4220D9CA8EEA01`).

Implements ROADMAP §1.3 + §1.4 (DRAFT spec-core.md + DRAFT spec-evidence.md) per the v0.8.2 plan PR V8.2-4.

## Why two specs, one PR

The two specs share status discipline, cross-reference each other (spec-evidence cites spec-core §3 for unknown fields, spec-evidence §6.2 references spec-core §10 for trust axiom, etc.), and both add a row to the same `docs/spec-status.md` registry. Splitting would force two row updates and decouple cross-references that need to land together.

## Design discipline locked across both specs

### Status banner + BCP 14 conventions

Both specs open with the same status banner template (DRAFT status, scope of restatement, cross-reference policy, conflict resolution pointer). §1 in each spec is the verbatim BCP 14 boilerplate from RFC 2119 / RFC 8174, with the explicit Normative vs Informative split: protocol rules are Normative; sections labeled "Example", "Rationale", "Migration Note", "Implementation Note" are Informative.

### Conformance profiles + version snapshots

Both specs declare the named-profile system in §2:

- **`PIC-Core`** — Action Proposal parsing, impact taxonomy, trust sanitization, tool binding, verifier outcomes. Passes `conformance/core/` + `conformance/trust_sanitization/`.
- **`PIC-Evidence`** — evidence object parsing, hash verification, signature verification, key lifecycle, trust upgrade. Passes `conformance/evidence/`.
- **`PIC-Full`** — both PIC-Core and PIC-Evidence. MUST NOT be claimed without satisfying both.

A conformance claim MUST identify both the profile name AND the spec snapshot/version (e.g., `PIC-Core / v0.8.2 DRAFT`). A DRAFT claim MUST NOT be represented as final PIC v1.0 conformance.

### Cite-don't-duplicate cross-reference strategy

Both specs CITE the frozen normative artifacts ([`RFC-0001`](docs/RFC-0001-pic-standard.md), [`canonicalization.md`](docs/canonicalization.md)) and the DRAFT companion ([`attestation-object-draft.md`](docs/attestation-object-draft.md)) rather than restating their normative content. The §14 / §19 "Normative Precedence and Conflict Resolution" section in each spec locks the precedence ordering and requires conflicts to be raised as Open Questions (Appendix C) rather than silently re-interpreted.

### Error-code stability (audited against actual emission)

Every error-code description in both specs was verified against actual `raise PICError(code=PICErrorCode.X, ...)` sites in `sdk-python/pic_standard/`. Notable finding: `PIC_POLICY_VIOLATION` is defined in the enum + TypeScript mirror but **never emitted** by the Python reference implementation (per CHANGELOG v0.6.x, policy-rule rejections are reported as `PIC_VERIFIER_FAILED`). Both specs document it as reserved-for-compat without requiring emission — preventing implementations from depending on a code that the reference doesn't produce.

The portable error-code namespace lock: when a conforming implementation reports a failure covered by one of the listed semantics, it MUST emit the corresponding identifier and MUST NOT substitute implementation-local or message-text-only identifiers. Freeform human-readable messages are Informative and MAY vary by language/locale.

### Conformance assertions decoupled from Python runner

The Conformance Assertions section in each spec ties prose to executable vectors but **does not require the Python runner**:

> An implementation claiming conformance to this DRAFT MUST produce the same pass/fail verdicts, expected error codes, and diagnostics for every listed vector. The Python runner (`python -m conformance.run`) is the current reference runner for this repository; non-Python implementations MAY use an equivalent runner, provided the selected vectors and reported outcomes match the reference contract.

This unblocks the v0.9.0 TypeScript verifier from being normatively gated on the Python runner.

### Error precedence — pinned where vectors cover it, open elsewhere

§9.2 in spec-core says implementations SHOULD emit the most-specific code whose precedence is pinned by conformance vectors. Total ordering for multi-failure edge cases is intentionally deferred to `OQ-CORE-001` — avoids false-precision conformance failures where two impls are both defensible but pick different first-error.

### Backward-compatible vs breaking changes

Both specs enumerate what counts as wire-format-breaking (field renames, impact-class meaning changes, trust-upgrade-semantics changes, canonicalization/digest changes, error-code renames, verdict changes for existing vectors) vs additive (new optional fields, new vectors, new stricter policy profiles, new attestation-version values, new reserved error codes).

### Open Questions Registry

Both specs have Appendix C with stable IDs (`OQ-CORE-001..003`, `OQ-EVIDENCE-001..004`) so DRAFT → final cleanup tracks every open item by ID rather than scattered inline annotations.

## spec-evidence.md highlights

**§6.2–6.4 load-bearing for PR V8.2-5** (the next PR in the v0.8.2 campaign). These three subsections specify the three-way signing-mode discriminator (legacy bytes vs canonical-mode vs canonical-looking-but-malformed), the canonical-bytes computation via PIC-CJSON/1.0, and post-signature digest binding against canonicalized proposal fields. PR V8.2-5 implements this surface in code.

**§6.2 three-way discriminator handles every parser outcome:** non-JSON payload, JSON non-object value (array/string/number/bool/null), JSON object without `attestation_version`, JSON object with non-string or unknown-string `attestation_version`, well-formed canonical object. The malformed-canonical and unknown-version cases MUST fail closed; no silent fallback to legacy bytes.

**§15 Security Considerations** covers key resolution, hash root confinement, signature payload canonicalization, revocation/expiry ordering (security property locked but check order intentionally implementation-flexible), sandboxed evidence resolution, no implicit trust upgrade.

**§9 Keyring resolver protocol** specifies the active-vs-inactive distinction as normative but explicitly does NOT over-specify a Python sentinel return shape — the concrete API MAY vary by implementation.

**§11.1 Error subset includes `PIC_SCHEMA_INVALID`** alongside `PIC_EVIDENCE_REQUIRED` / `PIC_EVIDENCE_FAILED` — internally consistent with §4 (unknown evidence types are schema-rejected) and `conformance/evidence/block/003_hash_invalid_sha256_format.json` (schema-level rejection of invalid digest format).

## spec-core.md highlights

**§5.2 Causal taint clarified as ID-binding + trust-level only.** Explicitly NOT natural-language claim evaluation. Prevents over-claiming what the verifier proves.

**§6.4 "Effective trust" defined once with computation order:** normalize → sanitize (when `strict_trust=True`) → evidence-driven upgrade. Scoped to the current verification only — MUST NOT be persisted, cached, or treated as durable reputation.

**§7 Tool-binding specifies exact string equality after JSON parsing.** MUST NOT apply case-folding, Unicode normalization, alias expansion, prefix matching, or tool-name rewriting. Closes a real ambiguity.

**§8 Verifier rules specified as invariants, not a total execution order.** The security-critical ordering is pinned explicitly: trust sanitization before evidence-driven upgrade; evidence upgrade before causal-taint check; tool-binding before tool dispatch. Other ordering choices are implementation-flexible. DoS-hardening MAY happen before or during any step.

**§2 PIC-Core / PIC-Evidence delegation discipline:** a PIC-Core implementation that does not implement PIC-Evidence MUST NOT mark evidence as verified or perform evidence-driven trust upgrade without delegating to a PIC-Evidence component. Prevents a "core-only" implementation from pretending evidence was verified.

**Trust-axiom and `semi_trusted` migration** documented normatively in §10 + Appendix A, mirroring [`migration-trust-sanitization.md`](docs/migration-trust-sanitization.md). The `PICTrustFutureWarning` mechanism is referenced as the Python reference impl's signaling — but the spec only requires "an operator-visible migration signal," not the specific Python warning class.

## spec-status.md update

New v0.8.2 row added to the post-RFC changelog table covering all of v0.8.2: evidence-mode vectors (PR #95), trust-sanitization matrix (PR #96), runner hardening (PR #97), this PR's DRAFT specs. Honest framing: "During runner-hardening, the default-invocation conformance runner human output format was preserved byte-identically relative to the post-vector baseline; vector counts changed only because new conformance vectors were added." (Does NOT claim byte-identical across the whole v0.8.2 campaign — that would be wrong.)

New "PIC/1.0 Specifications" section lists all four specs (PIC-CJSON, attestation-object DRAFT, spec-core DRAFT, spec-evidence DRAFT) with their status, profile coverage, and source paths. Includes the profile-name and DRAFT-status-discipline lock that the new specs cross-reference.

`vocabulary.md` deliberately NOT touched in this PR — defer to follow-up.

## Verification gate

- **Link/anchor validator** (custom Python script, `validate_spec_links.py`): OK — 3 docs validated, all relative links + section anchors resolve. Catches GitHub-flavored markdown slug rules including underscore preservation in identifiers (e.g., `args_digest` → anchor `#81-args_digest`).
- **`python -m conformance.run`**: 51/51 passed, exit 0 (defensive — no code touched).
- **Default-invocation runner stdout SHA**: still `0E1BD60BF0E6413F88937433BB0B130A153E570487B69C723E4220D9CA8EEA01` — byte-identical preservation maintained from PR V8.2-3.
- **`git diff --stat`**: only the three docs files (modify spec-status.md, new spec-evidence.md, new spec-core.md).
- **CI**: both PIC Conformance and full CI workflows green on commit pre-merge.

## Out of scope (intentionally deferred)

- **`docs/vocabulary.md` cross-references** to the new specs — cosmetic, defer to follow-up to keep this PR focused.
- **`docs/ERRORS.md` formalization** — v0.9.0 per v0.8.2 plan §5 locked exclusions.
- **TypeScript verifier first pass** — v0.9.0. These DRAFTs are the foundation for that work.
- **Producer-side helpers for canonical-signing-mode evidence** — v0.9.0+. spec-evidence §6 specifies the verifier side only.
- **Resolving the open questions** (`OQ-CORE-001..003`, `OQ-EVIDENCE-001..004`) — DRAFT → final cleanup work scheduled for v1.0 cross-implementation validation.

## Reviewer guidance

- **Status banners up top** — both specs open with explicit DRAFT framing. The cross-reference policy and conflict-resolution mechanism are stated in the banner before any normative text.
- **Normative vs Informative is declared in §1** — when in doubt about a section's binding force, check whether it's labeled Example / Rationale / Migration Note / Implementation Note (Informative) or unlabeled (Normative).
- **Cross-references go both ways** — spec-evidence cites spec-core §3 (unknown fields) and §10 (trust axiom); spec-core cites spec-evidence §8 (trust upgrade). The link/anchor validator confirms every cross-reference resolves both ways.
- **Open Questions registry replaces inline OQ blocks** — every open question has a stable ID in Appendix C of each spec. DRAFT → final cleanup tracks them; resolved items move to the changelog rather than being silently deleted.
- **Error-code stability descriptions are audited against `errors.py`** — every description was verified against actual emission sites in the Python SDK, not inferred from code names. `PIC_POLICY_VIOLATION` is reserved (not emitted by the reference impl) and explicitly documented as such.

## Diff stat

```
 docs/spec-core.md     | 706 +++++++++++++++++++++++++++++++++++++++++++++
 docs/spec-evidence.md | 769 ++++++++++++++++++++++++++++++++++++++++++++++++++
 docs/spec-status.md   |  47 +++
 3 files changed, 1522 insertions(+)
```

Commit on the branch: `83d6499e docs(spec): add DRAFT spec-core.md + spec-evidence.md (v0.8.2 PR 4)`.
