### PR TITLE
chore(release): bump to v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 This project follows Semantic Versioning:
 https://semver.org/
 
+## [0.8.2] - 2026-05-31
+
+Conformance + spec-drafts + opt-in canonical signing.
+
+### Added
+
+- **Evidence-mode conformance vectors** under `conformance/evidence/` (35 total: 14 hash/legacy-sig added in V8.2-1, plus 21 canonical/legacy-signing-mode added in V8.2-5). Covers hash + sig allow/block, sandbox + key-state, canonical-mode happy/minimal/mixed paths, three-way fail-closed discriminator (unknown `attestation_version`, non-string `attestation_version`, root/nested duplicate keys), digest binding, field binding, freshness, and digest-field shape rules.
+- **Trust-sanitization conformance vectors** under `conformance/trust_sanitization/` (24 vectors covering the `strict_trust × verify_evidence` matrix over representative proposal bases, lifted from `tests/test_trust_deprecation_warning.py::VERDICT_REGRESSION_MATRIX`).
+- **Conformance runner hardening**: `--json` machine-readable output, `--filter-mode <mode>` and `--filter-id <id>` filters with stable exit codes under filter, 8-token diagnostic taxonomy, manifest-error envelope, subprocess-based CLI test suite in `tests/test_conformance_runner.py`.
+- **Initial DRAFT `docs/spec-core.md`** — BCP 14 normative restatement of core verifier semantics (Trust Axiom, tool-binding, impact taxonomy, error identifiers). Defines the `PIC-Core` conformance profile. Not final-normative until PIC v1.0.
+- **Initial DRAFT `docs/spec-evidence.md`** — BCP 14 normative restatement of evidence verification (hash/sig modes, trust upgrade, keyring protocol, signing-mode discriminator, canonical-mode digest binding, freshness). Defines the `PIC-Evidence` conformance profile. Not final-normative until PIC v1.0.
+- **Opt-in canonical attestation-object signing** in the SDK evidence-verification path (`pic_standard.evidence`). Verifier detects canonical mode from a supported string-valued `attestation_version` in the parsed `sig` evidence payload (current allowlist: `{"PIC-ATT/1.0"}`); non-string and unknown-version values fail closed (no silent legacy fallback). Canonical mode computes signature over `canonicalize(parsed_attestation_object)` bytes per `docs/canonicalization.md §8.4`. Post-signature, canonical mode enforces digest binding (`args_digest` / `claims_digest` / `intent_digest` when present), tool/impact equality binding, `provenance_ids` proposal-array ordering, and `expires_at` freshness (strict RFC 3339 with explicit timezone designator; whitespace-padded and naive timestamps rejected).
+- **Persistent canonical-signing test suite** at `tests/test_evidence_canonical_signing.py` (24 scenarios), covering canonical happy/minimal paths, discriminator failures, digest/field binding, freshness, duplicate-key rejection, legacy preservation, mixed-mode verification, and post-canonical size caps. Keeps project coverage above the 80% gate.
+
+### Changed
+
+- **Conformance runner** human-readable output is preserved byte-identically relative to the post-vector baseline for the default invocation. `--json` mode adds machine-readable structured output; `--filter-mode`/`--filter-id` add CI-gate ergonomics. Exit codes are stable under filter (exit 2 with `no_vectors_selected` diagnostic when a filter target matches zero vectors).
+- **`docs/spec-status.md`** v0.8.2 row updated to reflect new conformance vector counts and the opt-in canonical-signing landing.
+
+### Notes
+
+- **Wire format unchanged.** The PIC/1.0 proposal and evidence schemas are byte-compatible with v0.8.1.1. Legacy-mode signature verification behavior remains compatible with all pre-V8.2-5 evidence vectors and tests.
+- **Canonical signing is opt-in.** A producer chooses canonical mode by emitting `attestation_version` in the signed payload. Producers that do not emit `attestation_version` continue to get legacy-mode (raw UTF-8 bytes of payload string) verification. Canonical-as-default is deferred to the PIC v1.0 track unless superseded by later DRAFT resolution.
+- **DRAFT spec discipline.** `docs/spec-core.md` and `docs/spec-evidence.md` are DRAFT until PIC v1.0 per ROADMAP §1.3/§1.4. Open questions are tracked in each spec's Appendix C with stable IDs (`OQ-CORE-*`, `OQ-EVIDENCE-*`) for cross-referencing.
+- **`docs/ERRORS.md` formalization deferred to v0.9.0.** Runner-side structured diagnostics from V8.2-3 feed into that work.
+- **TypeScript verifier first pass (`pic-standard-ts`) planned for v0.9.0.** This release lays its conformance foundation; the 72-vector suite is the cross-language contract the TS verifier will gate against.
+- **`semi_trusted` enum schema-level removal still scheduled for v0.9.0.** Currently deprecated since v0.8.1 with runtime normalization; this release does not change that trajectory.
+
+---
+
 ## [0.8.1.1] - 2026-05-11
 
 Shakedown release through the new signing infrastructure. **No protocol changes vs v0.8.1.**

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,8 @@ url: "https://github.com/madeinplutofabio/pic-standard"
 repository-artifact: "https://pypi.org/project/pic-standard/"
 license: "Apache-2.0"
 
-version: "0.8.1"
-date-released: "2026-05-07"
+version: "0.8.2"
+date-released: "2026-05-31"
 
 identifiers:
   - type: doi

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # PIC Standard — Enterprise-Ready Roadmap
 
 > Living plan for standardization, interop, and enterprise adoption.
-> Updated for the post-v0.8.1 repo state (2026-05-07).
+> Updated for the post-v0.8.2 repo state (2026-05-31).
 
 ---
 
@@ -74,7 +74,7 @@ Specifications in this project are treated as evolving drafts until cross-implem
 | **v0.8.0** | **Canonicalization foundation + conformance skeleton** | **PIC Canonical JSON v1 spec (frozen), reference implementation (`pic_standard.canonical`), 9 canonicalization vectors, refined attestation-object draft with byte-level digests, `conformance/` suite first pass, `conformance/manifest.json`, `python -m conformance.run`, `PIC Conformance` CI job** | ✅ Done |
 | **Phase 0 cleanup** | **Repo hygiene** | **`ROADMAP.md` committed, broken roadmap-link refs fixed, `semi_trusted` deprecation trajectory documented, `SECURITY.md`, `CODE_OF_CONDUCT.md`** | ✅ Done (PR #67) |
 | **v0.8.1** | **`semi_trusted` deprecation** | **`PICSemiTrustedDeprecationWarning` (defined in `pic_standard.verifier`, re-exported at package root, subclasses `FutureWarning`); pydantic field validator on `Provenance.trust` as the canonical normalization boundary; bridge helper in `verify_proposal()` triggers the validator immediately after JSON Schema validation, so the deprecation warning fires regardless of `strict_trust` mode and `semi_trusted` is normalized to `"untrusted"` before strict-trust flattening or evidence verification consume the dict; full `ActionProposal` instantiation stays last so `verify_causal_contract` keeps observing post-evidence trust state; examples migrated off `semi_trusted` (trust-flip only — no hash evidence added, since hash binds bytes not authority); migration doc `docs/migration-trust-sanitization.md` updated; verdict-regression matrix codified in `tests/test_trust_deprecation_warning.py` as a permanent CI guard. **Other v0.8.1-targeted items from the post-v0.8.0 plan (conformance expansion, runner hardening, initial DRAFTs of `spec-core.md` / `spec-evidence.md`) are deferred to v0.8.2 to keep this release focused on the deprecation surface.** | ✅ Done |
-| **v0.8.2** | **Conformance expansion + runner hardening + initial spec drafts + canonical runtime signing (opt-in)** | **(Deferred from v0.8.1) Evidence-mode vectors, trust-sanitization vectors, runner hardening (JSON output, run-by-id/mode, machine-readable failure reporting), initial DRAFT `docs/spec-core.md`, initial DRAFT `docs/spec-evidence.md`. (v0.8.2 native) Canonical attestation-object bytes wired into runtime signing/verification flow as an opt-in mode (default remains legacy payload-string for one release). Attestation Object v1 remains DRAFT during this stabilization phase. Legacy mode explicitly demoted to compatibility mode in docs.** | Planned |
+| **v0.8.2** | **Conformance expansion + runner hardening + initial spec drafts + canonical runtime signing (opt-in)** | **(Deferred from v0.8.1) Evidence-mode vectors, trust-sanitization vectors, runner hardening (JSON output, run-by-id/mode, machine-readable failure reporting), initial DRAFT `docs/spec-core.md`, initial DRAFT `docs/spec-evidence.md`. (v0.8.2 native) Canonical attestation-object bytes wired into runtime signing/verification flow as an opt-in mode (default remains legacy payload-string for one release). Attestation Object v1 remains DRAFT during this stabilization phase. Legacy mode explicitly demoted to compatibility mode in docs.** | ✅ Done |
 | **v0.9.0** | **Interop milestone + schema cleanup** | **First TypeScript verifier pass — minimum: canonicalization + core + trust-sanitization mode parity with Python on the same `conformance/manifest.json`, filtered to those three modes. `semi_trusted` removed from schema (was deprecated in v0.8.1). OpenAPI bridge spec, structured audit logs, Docker hardening for enterprise pilots. Spec drafts updated with cross-impl findings.** | Planned |
 | v0.9.1–v0.9.2 | Ambiguity burn-down | Differential Python ↔ TS testing, fuzzing canonicalization and malformed proposals/evidence, more number/Unicode edge vectors, additional malformed-evidence cases, TS evidence-mode parity completed if not landed at v0.9.0, wording tightening from cross-impl disagreements | Planned |
 | **v1.0.0** | **Production-grade protocol freeze** | **`strict_trust=True` becomes default and only conformant mode. Canonical attestation-object signing becomes default; legacy payload-string mode is non-conformant. `spec-core.md`, `spec-evidence.md`, and Attestation Object v1 all promoted to normative. PIC-CJSON/1.0 unchanged. Python + TS pass full conformance suite. Internet-Draft submission.** | Planned |
@@ -83,7 +83,7 @@ Specifications in this project are treated as evolving drafts until cross-implem
 
 ---
 
-## Current State (post-v0.8.1)
+## Current State (post-v0.8.2)
 
 ### What exists
 
@@ -480,13 +480,13 @@ These are important but stay downstream of a stable core:
 | # | PR | Phase | Target |
 |---|----|-------|--------|
 | 1 | **Phase 0 hygiene PR**: commit ROADMAP.md, fix broken roadmap-link refs, document `semi_trusted` deprecation trajectory (Path B: deprecate v0.8.1, remove v0.9.0), add SECURITY.md and CODE_OF_CONDUCT.md | 0 | ✅ Done (PR #67) |
-| 2 | Conformance expansion: evidence-mode + trust-sanitization vectors | 1.2 | v0.8.2 (deferred from v0.8.1) |
-| 3 | Runner hardening: JSON output, filtering, machine-readable diagnostics | 1.2 | v0.8.2 (deferred from v0.8.1) |
-| 4 | Initial DRAFT `docs/spec-core.md` | 1.3 | v0.8.2 (deferred from v0.8.1) |
-| 5 | Initial DRAFT `docs/spec-evidence.md` | 1.4 | v0.8.2 (deferred from v0.8.1) |
+| 2 | Conformance expansion: evidence-mode + trust-sanitization vectors | 1.2 | ✅ Done (v0.8.2) |
+| 3 | Runner hardening: JSON output, filtering, machine-readable diagnostics | 1.2 | ✅ Done (v0.8.2) |
+| 4 | Initial DRAFT `docs/spec-core.md` | 1.3 | ✅ Done (v0.8.2) |
+| 5 | Initial DRAFT `docs/spec-evidence.md` | 1.4 | ✅ Done (v0.8.2) |
 | 6 | `semi_trusted` deprecation: `PICSemiTrustedDeprecationWarning` + canonical normalization at the model-validation boundary (pydantic field validator on `Provenance.trust` + bridge helper triggering it after JSON Schema validation) + example trust-flips + migration note + verdict-regression matrix | 1.6 | ✅ Done (v0.8.1) |
-| 7 | Wire canonical attestation signing into runtime as opt-in mode (against draft Attestation v1) | 1.5 | v0.8.2 |
-| 8 | `docs/ERRORS.md` formalization | 2.1 | v0.8.2 / v0.9.0 |
+| 7 | Wire canonical attestation signing into runtime as opt-in mode (against draft Attestation v1) | 1.5 | ✅ Done (v0.8.2) |
+| 8 | `docs/ERRORS.md` formalization | 2.1 | v0.9.0 |
 | 9 | `semi_trusted` removal: schema enum drop + code cleanup | 1.6 | v0.9.0 |
 | 10 | OpenAPI + Docker hardening + structured audit logs | 2 | v0.9.0 |
 | 11 | First `pic-standard-ts` verifier pass (canon + core + trust-sanitization minimum) | 3 | v0.9.0 |

--- a/docs/spec-status.md
+++ b/docs/spec-status.md
@@ -20,7 +20,7 @@
 
 The PIC/1.0 proposal structure and wire-level schema have remained stable since the RFC anchor. Post-RFC changes in v0.6.x–v0.8.x primarily affected shared pipeline behavior, trust resolution, integration surface, runtime efficiency, and canonicalization/conformance tooling rather than introducing a wire-format break.
 
-**Current Python reference implementation:** v0.8.1
+**Current Python reference implementation:** v0.8.2
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pic-standard"
-version = "0.8.1.1"
+version = "0.8.2"
 description = "PIC Standard: Provenance & Intent Contracts for agentic side-effect governance"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Version bump and release-state hygiene for v0.8.2.

5 files updated:
- `pyproject.toml` — version `0.8.1.1` → `0.8.2`
- `CHANGELOG.md` — new `[0.8.2]` entry
- `CITATION.cff` — version + date-released
- `docs/spec-status.md` — current Python reference implementation marker
- `ROADMAP.md` — current-state header + status-column flips for shipped V8.2-1..5 items

Wire format unchanged. v0.8.2's substantive scope (conformance + spec drafts + opt-in canonical signing) shipped in PRs #95-#99. See the new `[0.8.2]` entry in `CHANGELOG.md` for the full release notes.

The signed tag `v0.8.2` lands in a separate step per `RELEASING.md` after this PR merges, triggering `.github/workflows/release.yml` (build + PyPI publish gated by the `pypi` GitHub Environment approval + GitHub Release creation).

## Test plan

- [ ] CI green (test-python on 3.10/3.11/3.12, test-openclaw, Conformance vectors, DCO)
- [ ] `git diff main..chore/v0.8.2-release --stat` shows exactly the 5 files / `+43 / -13`
- [ ] Manual scan: `pyproject.toml` line 7 reads `version = "0.8.2"`
- [ ] Manual scan: `CHANGELOG.md` top of versioned entries reads `## [0.8.2] - 2026-05-31`
