### PR TITLE
chore(citation): add Zenodo Version DOIs for v0.8.1.1 and v0.8.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,6 +23,12 @@ identifiers:
   - type: doi
     value: "10.5281/zenodo.20072579"
     description: "Version DOI for v0.8.1 (archived 2026-05-07)"
+  - type: doi
+    value: "10.5281/zenodo.20125662"
+    description: "Version DOI for v0.8.1.1 (archived 2026-05-11)"
+  - type: doi
+    value: "10.5281/zenodo.20476984"
+    description: "Version DOI for v0.8.2 (archived 2026-05-31)"
 
 keywords:
   - ai-safety


### PR DESCRIPTION
Backfills the v0.8.1.1 Zenodo Version DOI and adds the v0.8.2 Version DOI to CITATION.cff. Pure metadata update.