### PR TITLE
chore(community): add FUNDING.yml (GitHub Sponsors)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Funding sources for PIC Standard.
+# GitHub Sponsors button activates once Sponsors onboarding is complete.
+github: madeinplutofabio


### PR DESCRIPTION
Adds a Sponsor funding target so the repo shows a Sponsor button (activates once GitHub Sponsors onboarding is complete). Part of the community-health quick fixes.