### PR TITLE
chore(community): refresh FUNDING.yml (re-parse Sponsor link)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,2 @@
-# Funding sources for PIC Standard.
-# GitHub Sponsors button activates once Sponsors onboarding is complete.
+# Funding for PIC Standard
 github: madeinplutofabio


### PR DESCRIPTION
Touch FUNDING.yml so GitHub re-parses funding links now that the GitHub Sponsors listing is published. The original parse at #103 cached an empty result because Sponsors was not yet enabled.