### PR TITLE
chore: retarget repo URLs to pic-standard org

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ authors:
     family-names: Salvadori
     # orcid: "https://orcid.org/0000-0000-0000-0000"  # add if you have one
 
-repository-code: "https://github.com/madeinplutofabio/pic-standard"
-url: "https://github.com/madeinplutofabio/pic-standard"
+repository-code: "https://github.com/pic-standard/pic-standard"
+url: "https://github.com/pic-standard/pic-standard"
 repository-artifact: "https://pypi.org/project/pic-standard/"
 license: "Apache-2.0"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Pinned on 2026-04-01 for reproducible builds.
 FROM python:3.12-slim@sha256:3d5ed973e45820f5ba5e46bd065bd88b3a504ff0724d85980dcd05eab361fcf4
 
-LABEL org.opencontainers.image.source="https://github.com/madeinplutofabio/pic-standard" \
+LABEL org.opencontainers.image.source="https://github.com/pic-standard/pic-standard" \
     org.opencontainers.image.description="PIC Standard HTTP Bridge" \
     org.opencontainers.image.licenses="Apache-2.0"
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -74,7 +74,7 @@ The project's operational surface is intentionally narrow:
 
 - The repository is licensed **Apache-2.0**, which grants all rights necessary for the project to be forked and continued under new maintainership without requiring permission from the original author or their estate.
 - Inbound contributions are governed by Apache-2.0 §5 (inbound = outbound), so the contribution graph requires no further licensing action to continue.
-- The project name "PIC Standard" and the GitHub repository under `madeinplutofabio/pic-standard` are not registered trademarks. A successor maintainer may continue under the same name or fork under a new one.
+- The project name "PIC Standard" and the GitHub repository under `pic-standard/pic-standard` are not registered trademarks. A successor maintainer may continue under the same name or fork under a new one.
 
 ### Designated successor
 
@@ -90,7 +90,7 @@ Activation procedure:
    - Credentials for `team@madeinpluto.com`
    - A signed letter from the Lead Maintainer authorizing the successor to act on the project under Apache-2.0
 2. Using those credentials, the successor either (a) appoints a technical maintainer of her choice and transfers GitHub repository ownership and PyPI co-owner rights, or (b) publishes a final maintenance release and archives the repository.
-3. Apache-2.0 grants any third party the independent right to fork and continue the project, so the successor's authority is not the only path to continuity — it is the path that preserves the official `madeinplutofabio/pic-standard` and PyPI `pic-standard` namespaces.
+3. Apache-2.0 grants any third party the independent right to fork and continue the project, so the successor's authority is not the only path to continuity — it is the path that preserves the official `pic-standard/pic-standard` and PyPI `pic-standard` namespaces.
 
 The successor's contact details are held privately and not published in this file. Verification in a continuity event is via possession of the sealed envelope and recovery codes.
 
@@ -106,7 +106,7 @@ If the Lead Maintainer becomes unavailable per the definition above:
 
 ## Contact
 
-- **General project questions** — open an issue at <https://github.com/madeinplutofabio/pic-standard/issues>.
+- **General project questions** — open an issue at <https://github.com/pic-standard/pic-standard/issues>.
 - **Security disclosures** — use GitHub Security Advisories per `SECURITY.md`. Do not file public issues for security bugs.
 - **Code of conduct** — team@madeinpluto.com per `CODE_OF_CONDUCT.md`.
 - **Continuity activation** — open a public issue using the title format above.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# <p><img src="https://raw.githubusercontent.com/madeinplutofabio/pic-standard/main/picico.png" height="60" align="absmiddle"> PIC Standard: Provenance & Intent Contracts</p>
+# <p><img src="https://raw.githubusercontent.com/pic-standard/pic-standard/main/picico.png" height="60" align="absmiddle"> PIC Standard: Provenance & Intent Contracts</p>
 
 **Local-first action gating for AI agents. Verify intent, provenance, and evidence before any high-impact tool call executes.**
 
 [![PyPI version](https://img.shields.io/pypi/v/pic-standard.svg?logo=pypi&logoColor=white)](https://pypi.org/project/pic-standard/)
 [![PyPI downloads](https://img.shields.io/pypi/dm/pic-standard.svg?logo=pypi&logoColor=white)](https://pypi.org/project/pic-standard/)
-[![Signed releases](https://img.shields.io/badge/signed%20releases-Sigstore%20%2B%20SSH-brightgreen)](https://github.com/madeinplutofabio/pic-standard/blob/main/RELEASING.md)
+[![Signed releases](https://img.shields.io/badge/signed%20releases-Sigstore%20%2B%20SSH-brightgreen)](https://github.com/pic-standard/pic-standard/blob/main/RELEASING.md)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12790/badge)](https://www.bestpractices.dev/projects/12790)
-[![CI](https://github.com/madeinplutofabio/pic-standard/actions/workflows/ci.yml/badge.svg)](https://github.com/madeinplutofabio/pic-standard/actions/workflows/ci.yml)
+[![CI](https://github.com/pic-standard/pic-standard/actions/workflows/ci.yml/badge.svg)](https://github.com/pic-standard/pic-standard/actions/workflows/ci.yml)
 [![Code style: Ruff](https://img.shields.io/badge/code%20style-ruff-D7FF64)](https://docs.astral.sh/ruff/)
-[![Coverage](https://img.shields.io/badge/coverage-%E2%89%A580%25-brightgreen)](https://github.com/madeinplutofabio/pic-standard/blob/main/pyproject.toml)
-[![Last commit](https://img.shields.io/github/last-commit/madeinplutofabio/pic-standard)](https://github.com/madeinplutofabio/pic-standard/commits/main)
-[![GitHub stars](https://img.shields.io/github/stars/madeinplutofabio/pic-standard?style=social)](https://github.com/madeinplutofabio/pic-standard)
+[![Coverage](https://img.shields.io/badge/coverage-%E2%89%A580%25-brightgreen)](https://github.com/pic-standard/pic-standard/blob/main/pyproject.toml)
+[![Last commit](https://img.shields.io/github/last-commit/pic-standard/pic-standard)](https://github.com/pic-standard/pic-standard/commits/main)
+[![GitHub stars](https://img.shields.io/github/stars/pic-standard/pic-standard?style=social)](https://github.com/pic-standard/pic-standard)
 [![DOI](http://img.shields.io/badge/DOI-10.5281%20%2F%20zenodo.18725562-blue.svg)](https://doi.org/10.5281/zenodo.18725562)
-[![License](https://img.shields.io/github/license/madeinplutofabio/pic-standard)](https://github.com/madeinplutofabio/pic-standard/blob/main/LICENSE)
+[![License](https://img.shields.io/github/license/pic-standard/pic-standard)](https://github.com/pic-standard/pic-standard/blob/main/LICENSE)
 
 PIC is a lightweight, local-first protocol that forces AI agents to **prove** every important action before it happens. Agents must declare intent, impact, provenance, and evidence; PIC verifies everything and **fails closed** if anything is wrong.
 
@@ -83,7 +83,7 @@ pip install "pic-standard[crypto]"     # Ed25519 signature evidence
 
 **From source (contributors):**
 ```bash
-git clone https://github.com/madeinplutofabio/pic-standard.git
+git clone https://github.com/pic-standard/pic-standard.git
 cd pic-standard && pip install -e ".[langgraph,mcp,crypto]"
 pytest -q
 ```
@@ -270,7 +270,7 @@ Verify locally: `sha256sum -c docs/RFC-0001.SHA256`
 
 ## Project info
 
-- **Security policy** — see [`SECURITY.md`](SECURITY.md). Report vulnerabilities privately via [GitHub Security Advisories](https://github.com/madeinplutofabio/pic-standard/security/advisories/new); do not file public issues for security reports.
+- **Security policy** — see [`SECURITY.md`](SECURITY.md). Report vulnerabilities privately via [GitHub Security Advisories](https://github.com/pic-standard/pic-standard/security/advisories/new); do not file public issues for security reports.
 - **Code of conduct** — see [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md). PIC follows the [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/). Reports go to `team@madeinpluto.com`.
 - **Citation** — see [`CITATION.cff`](CITATION.cff) for full citation metadata. The Zenodo concept DOI [10.5281/zenodo.18725562](https://doi.org/10.5281/zenodo.18725562) (badged at the top of this page) resolves to the latest archived release on Zenodo; per-version DOIs are listed on the Zenodo record.
 - **Foundation-track feedback** — PIC Standard has undergone [AAIF project-proposal review](https://github.com/aaif/project-proposals/issues/16#issuecomment-4455960990). The technical positioning was recognized; the current focus is expanding multi-organization maintainership, production adoption, and standards-track readiness.
@@ -291,7 +291,7 @@ Good first contribution areas right now: conformance vectors, OpenAPI spec, TS v
 
 If you find PIC useful, please consider giving us a star on GitHub: it helps attract more security experts and framework authors into the community.
 
-Issues & ideas: [GitHub Issues](https://github.com/madeinplutofabio/pic-standard/issues)
+Issues & ideas: [GitHub Issues](https://github.com/pic-standard/pic-standard/issues)
 
 Maintained by [![Linkedin](https://i.sstatic.net/gVE0j.png) @fmsalvadori](https://www.linkedin.com/in/fmsalvadori/)
 &nbsp;

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,7 +15,7 @@ The release pipeline produces two distinct signed artifacts, verifiable through 
 
 ### Layer 1: PyPI distribution artifacts (wheel + sdist)
 
-Built and uploaded to PyPI by `.github/workflows/release.yml`. Each upload is accompanied by a **PEP 740 attestation** — a Sigstore-issued, transparency-logged signature binding the artifact bytes to a specific GitHub Actions workflow identity (`madeinplutofabio/pic-standard`, workflow `release.yml`, environment `pypi`).
+Built and uploaded to PyPI by `.github/workflows/release.yml`. Each upload is accompanied by a **PEP 740 attestation** — a Sigstore-issued, transparency-logged signature binding the artifact bytes to a specific GitHub Actions workflow identity (`pic-standard/pic-standard`, workflow `release.yml`, environment `pypi`).
 
 - **What proves authenticity:** PyPI publishes the attestation alongside the artifact. The Sigstore-issued certificate is short-lived (per-workflow-run, ephemeral) but cryptographically tied to a GitHub Actions OIDC token claim that asserts "this workflow ran in this repo from this environment." Trust roots back to GitHub's OIDC issuer + Sigstore's public transparency log.
 - **What you do to verify:** install `pypi-attestations` (a FLOSS CLI from PyPA), point it at the artifact, and the tool fetches the attestation from PyPI and validates the entire chain. See "For users" below for the command.
@@ -103,19 +103,19 @@ pip install pypi-attestations
 # Against a local file
 pip download --no-deps pic-standard==<version>
 pypi-attestations verify pypi \
-    --repository https://github.com/madeinplutofabio/pic-standard \
+    --repository https://github.com/pic-standard/pic-standard \
     pic_standard-<version>-py3-none-any.whl
 
 # Or against the PyPI URL directly (no local download)
 pypi-attestations verify pypi \
-    --repository https://github.com/madeinplutofabio/pic-standard \
+    --repository https://github.com/pic-standard/pic-standard \
     https://files.pythonhosted.org/packages/.../pic_standard-<version>-py3-none-any.whl
 ```
 
 **What the tool checks:**
 
 - Fetches the attestation from PyPI
-- Validates the Sigstore-issued certificate against the Trusted Publisher policy (workflow `release.yml` from `madeinplutofabio/pic-standard`)
+- Validates the Sigstore-issued certificate against the Trusted Publisher policy (workflow `release.yml` from `pic-standard/pic-standard`)
 - Confirms the artifact bytes match the attestation's payload hash
 - Cross-references the Sigstore transparency log
 
@@ -164,7 +164,7 @@ git config --global gpg.format ssh   # WARNING: applies globally — see note
 
 ⚠️ Note: `gpg.format ssh` is repo-local in our project setup (per `CONTRIBUTING.md`), but if you set it globally it affects every repo that signs tags/commits. If you sign for another project using GPG, don't set this globally.
 
-**Alternative (GitHub web UI):** GitHub shows tag verification status in the **Releases → Tags** view (https://github.com/madeinplutofabio/pic-standard/tags). A "Verified" indicator on a tag reflects GitHub's server-side check against the maintainer's registered Signing Key, equivalent verification to running `git tag -v` locally.
+**Alternative (GitHub web UI):** GitHub shows tag verification status in the **Releases → Tags** view (https://github.com/pic-standard/pic-standard/tags). A "Verified" indicator on a tag reflects GitHub's server-side check against the maintainer's registered Signing Key, equivalent verification to running `git tag -v` locally.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,7 +70,7 @@ PGP-signed reports and acknowledgments are not currently supported — no mainta
 
 PIC Standard releases produced via the project's release pipeline are cryptographically signed in two complementary ways:
 
-- **PyPI distribution artifacts** (wheel + sdist): signed via [PEP 740 attestations](https://peps.python.org/pep-0740/) (Sigstore-backed, tied to a GitHub Actions Trusted Publisher workflow identity — `madeinplutofabio/pic-standard` running `release.yml` under the `pypi` environment).
+- **PyPI distribution artifacts** (wheel + sdist): signed via [PEP 740 attestations](https://peps.python.org/pep-0740/) (Sigstore-backed, tied to a GitHub Actions Trusted Publisher workflow identity — `pic-standard/pic-standard` running `release.yml` under the `pypi` environment).
 - **Git tags**: signed with the project's dedicated Ed25519 release-signing key (the public half is pinned in [`.github/release-signing-key.pub`](.github/release-signing-key.pub)).
 
 For verification commands, the trusted public signing key + SHA256 fingerprint, troubleshooting, and key rotation procedure, see **[`RELEASING.md`](RELEASING.md)**.

--- a/docs/RFC-0001.SHA256
+++ b/docs/RFC-0001.SHA256
@@ -1,23 +1,21 @@
 # RFC-0001 Spec Fingerprint Manifest
-# Generated: 2026-02-21
+# Generated: 2026-06-22
 # Verify (from repo root): sha256sum -c docs/RFC-0001.SHA256
 #
-# This file anchors RFC-0001 to the canonical source artifacts
-# at the time of publication. The RFC itself is also anchored by
-# the Git commit hash that introduces it.
-
+# This file anchors RFC-0001 to the canonical source artifacts.
+# The RFC is also anchored by the Git commit hash that introduces it.
+# Re-anchored 2026-06-22 after the org migration to pic-standard/pic-standard;
+# pyproject.toml (URL metadata) and CHANGELOG.md have advanced since initial
+# publication. The original fingerprint remains in the Zenodo archive + commit.
 # --- RFC document ---
 29cc941e553869d05a24d94f5036582e844747caef416e870257955da268e5a1  docs/RFC-0001-pic-standard.md
-
 # --- PIC/1.0 schema ---
 910ab13433875b7824449c387a6652eff1f61a0b597b3ac0dd86537d0734e89a  sdk-python/pic_standard/schemas/proposal_schema.json
-
 # --- Core enforcement modules ---
-f4c0dc74ce367b27e111c8f28cf9ce0686f6c40dedf13cd52a288f00363ea2ed  sdk-python/pic_standard/verifier.py
-b14b600a8d1738c616285a39c14bba14dbe0d9f52763e870b5c96b77b2b2caec  sdk-python/pic_standard/evidence.py
-8a572fa527f7f592c65166fea02e5b580144af5a2568bd89b8385b360fdfae9f  sdk-python/pic_standard/keyring.py
-e94d2da396283ffc2078ae7a5ee6613c23311b511b6dc1feefbbe47f084d7376  sdk-python/pic_standard/integrations/mcp_pic_guard.py
-
+9b1115384e6e7fb8f316ea70b8e468779a184260f6b544d915389506801bc54b  sdk-python/pic_standard/verifier.py
+9286b5111f82606f99fecad445f554fe423b8dc5e647bff6d65f45538c6250b2  sdk-python/pic_standard/evidence.py
+eb87b1ed4c5a23f93a4c600c73d682914106ac8592983670868090f3afc4c58c  sdk-python/pic_standard/keyring.py
+68fe105c5e3bce0ad241d80537b7010fd25b55c135ae2c65674e3a9f65f3620e  sdk-python/pic_standard/integrations/mcp_pic_guard.py
 # --- Context anchors (version + history) ---
-b3974a038aae75454a9f614811872dc3714250c616e89bbf033b6b35615054be  pyproject.toml
-3dc2100397c008a2b0deab16821cfa5b49f6d5fc53f565e599f00c584c5696b3  CHANGELOG.md
+ea803150ae1462b0a137952040555d1f685be62eac465bd2a82265d3e76815f6  pyproject.toml
+5db24a74aaac62259ec408cbf22a4466ce58539d9155800048b33ed99364f60a  CHANGELOG.md

--- a/docs/fail-closed-evidence-mcp.md
+++ b/docs/fail-closed-evidence-mcp.md
@@ -218,7 +218,7 @@ If you’ve shipped tool-calling agents with real side effects:
 
 ## Appendix: quick links
 
-- Repo + README + examples: https://github.com/madeinplutofabio/pic-standard
+- Repo + README + examples: https://github.com/pic-standard/pic-standard
 - Evidence demos: `examples/financial_hash_ok.json` and `examples/failing/financial_hash_bad.json`
 - MCP demos: `examples/mcp_pic_server_demo.py` + `examples/mcp_pic_client_demo.py`
 - LangGraph demo: `examples/langgraph_pic_toolnode_demo.py`

--- a/integrations/openclaw/package.json
+++ b/integrations/openclaw/package.json
@@ -41,14 +41,14 @@
     ],
     "author": "Fabio Marcello Salvadori",
     "license": "Apache-2.0",
-    "homepage": "https://github.com/madeinplutofabio/pic-standard/tree/main/integrations/openclaw",
+    "homepage": "https://github.com/pic-standard/pic-standard/tree/main/integrations/openclaw",
     "repository": {
         "type": "git",
-        "url": "https://github.com/madeinplutofabio/pic-standard.git",
+        "url": "https://github.com/pic-standard/pic-standard.git",
         "directory": "integrations/openclaw"
     },
     "bugs": {
-        "url": "https://github.com/madeinplutofabio/pic-standard/issues"
+        "url": "https://github.com/pic-standard/pic-standard/issues"
     },
     "peerDependencies": {
         "openclaw": ">=2026.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,9 @@ mcp = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/madeinplutofabio/pic-standard"
-Repository = "https://github.com/madeinplutofabio/pic-standard"
-Issues = "https://github.com/madeinplutofabio/pic-standard/issues"
+Homepage = "https://github.com/pic-standard/pic-standard"
+Repository = "https://github.com/pic-standard/pic-standard"
+Issues = "https://github.com/pic-standard/pic-standard/issues"
 
 [project.scripts]
 pic-cli = "pic_standard.cli:main"


### PR DESCRIPTION
Follow-up to the GitHub org transfer (`madeinplutofabio/pic-standard` → `pic-standard/pic-standard`).

## What changed
- Retargeted hard-coded `madeinplutofabio/pic-standard` repo-path URLs to `pic-standard/pic-standard` across: `README.md` (badges/clone/security/issues), `pyproject.toml` `[project.urls]`, `CITATION.cff`, `Dockerfile` OCI label, `SECURITY.md` + `RELEASING.md` Trusted-Publisher identity strings, `integrations/openclaw/package.json`, `MAINTAINERS.md`, and `docs/fail-closed-evidence-mcp.md`.
- Regenerated `docs/RFC-0001.SHA256` so `sha256sum -c docs/RFC-0001.SHA256` passes again (verified locally, all 8 entries OK). This also repairs **pre-existing** fingerprint drift on `pyproject.toml` and `CHANGELOG.md` that predated this PR.

## Intentionally NOT changed
- **Account-scoped references** stay on the personal account: `.github/FUNDING.yml` (`github: madeinplutofabio` Sponsors recipient), the `@madeinplutofabio` handle and account-recovery notes in `MAINTAINERS.md`, the signing-key comment labels in `RELEASING.md`, and the `GOVERNANCE.md` attribution.
- **`docs/RFC-0001-pic-standard.md`** keeps its original URLs by design (defensive-publication document; old links resolve via GitHub redirect). Its hash is unchanged and still anchored.
- **`.github/release-signing-key.pub`** — crypto material untouched.

## Follow-ups (outside this PR, external platforms)
- [ ] PyPI Trusted Publisher: update owner `madeinplutofabio` → `pic-standard` (same repo/workflow/env) before next release
- [ ] Reconnect Zenodo↔GitHub integration
- [ ] Update OpenSSF Best Practices (project 12790) repo URL
- [ ] Republish `pic-guard` npm with updated repository metadata