### PR TITLE
docs(contributing): add good-first-contribution funnel block

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,16 @@
 
 Thank you for helping us build a more accountable future for AI. 🛡️
 
+## New here? Start with a good first contribution
+
+The fastest ways in:
+
+- Read the [call for contributors](https://github.com/pic-standard/pic-standard/discussions/117).
+- Pick a [good first issue](https://github.com/pic-standard/pic-standard/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) or one of the pinned issues, then comment to claim it.
+- Adding a conformance vector is a great first PR: follow [`conformance/adding-a-vector.md`](conformance/adding-a-vector.md).
+
+A maintainer will help if you get stuck. The path to Reviewer and Maintainer is documented in [`GOVERNANCE.md`](GOVERNANCE.md).
+
 ## ✍️ Developer Certificate of Origin (DCO)
 
 PIC Standard uses the [Developer Certificate of Origin](https://developercertificate.org/) (DCO) for individual contributions. All commits to this repository **must be signed off** under the DCO. The DCO is a lightweight, per-commit attestation that you have the right to submit the contribution under the project's Apache 2.0 license.


### PR DESCRIPTION
Adds a short **New here? Start with a good first contribution** section at the top of
CONTRIBUTING.md (right after the intro, before DCO), linking:

- the [call for contributors discussion](https://github.com/pic-standard/pic-standard/discussions/117)
- the good-first-issue label filter and pinned issues
- the conformance-vector guide (`conformance/adding-a-vector.md`)
- the path to Reviewer/Maintainer in `GOVERNANCE.md`

Closes the last open funnel item from the migration plan. Docs-only change.