### PR TITLE
fix(cli): make CLI and demo runtime output ASCII-safe on Windows

### DIFF
--- a/examples/_gen_sig_example.py
+++ b/examples/_gen_sig_example.py
@@ -60,7 +60,7 @@ def main() -> None:
     bad["evidence"][0]["signature"] = _b64(sig_bad)
     BAD_PATH.write_text(json.dumps(bad, indent=4), encoding="utf-8")
 
-    print("✅ Wrote:")
+    print("PASS: Wrote:")
     print(f" - {KEYS_EXAMPLE_PATH.relative_to(REPO_ROOT)}")
     print(f" - {OK_PATH.relative_to(REPO_ROOT)}")
     print(f" - {BAD_PATH.relative_to(REPO_ROOT)}")

--- a/examples/langgraph_pic_toolnode_demo.py
+++ b/examples/langgraph_pic_toolnode_demo.py
@@ -73,9 +73,9 @@ def main():
             ]
         }
         node.invoke(state)
-        print("❌ unexpected: untrusted money proposal should have been blocked")
+        print("FAIL: unexpected: untrusted money proposal should have been blocked")
     except Exception as e:
-        print("✅ blocked as expected (untrusted money)")
+        print("PASS: blocked as expected (untrusted money)")
         print("   ", pretty_error(e))
         print()
 
@@ -98,10 +98,10 @@ def main():
         out = node.invoke(state)
         msgs = out.get("messages", [])
         result = msgs[0].content if msgs else "<no output>"
-        print("✅ allowed as expected (trusted money)")
+        print("PASS: allowed as expected (trusted money)")
         print("   ", result)
     except Exception as e:
-        print("❌ unexpected: trusted money proposal should have been allowed")
+        print("FAIL: unexpected: trusted money proposal should have been allowed")
         print("   ", pretty_error(e))
 
 

--- a/examples/mcp_pic_client_demo.py
+++ b/examples/mcp_pic_client_demo.py
@@ -89,20 +89,20 @@ def _extract_pic_envelope(resp: Any) -> Optional[dict]:
 def _print_pic(resp: Any, *, expect_block: bool) -> None:
     env = _extract_pic_envelope(resp)
     if env is None:
-        print("❌ could not parse PIC envelope from MCP response")
+        print("FAIL: could not parse PIC envelope from MCP response")
         print(resp)
         return
 
     is_err = bool(env.get("isError"))
 
     if is_err and expect_block:
-        print("✅ blocked as expected")
+        print("PASS: blocked as expected")
     elif (not is_err) and (not expect_block):
-        print("✅ allowed as expected")
+        print("PASS: allowed as expected")
     elif is_err and (not expect_block):
-        print("❌ unexpected: trusted money should have been allowed")
+        print("FAIL: unexpected: trusted money should have been allowed")
     else:
-        print("❌ unexpected: untrusted money should have been blocked")
+        print("FAIL: unexpected: untrusted money should have been blocked")
 
     print(json.dumps(env, indent=2, ensure_ascii=False))
 

--- a/examples/openclaw_pic_bridge_demo.py
+++ b/examples/openclaw_pic_bridge_demo.py
@@ -151,7 +151,7 @@ def run_demo(base_url: str) -> None:
 # --- Main --------------------------------------------------------------------
 
 def main() -> None:
-    log.info("Policy: payments_send → money (high-impact)")
+    log.info("Policy: payments_send -> money (high-impact)")
 
     server = PICBridgeServer(
         ("127.0.0.1", 0),  # port 0 = OS-assigned random port

--- a/sdk-python/crewai_pic_tool.py
+++ b/sdk-python/crewai_pic_tool.py
@@ -11,10 +11,10 @@ class PICProtectedTool(BaseTool):
         # 1. Intercept the call
         # 2. Run the Verifier
         if pic_contract.get("impact") == "money" and not self.has_trusted_evidence(pic_contract):
-            return "❌ Access Denied: PIC Contract Violation. No trusted provenance."
+            return "Access Denied: PIC Contract Violation. No trusted provenance."
 
         # 3. Only execute if valid
-        return f"✅ Payment of ${amount} to {recipient} authorized via PIC."
+        return f"Payment of ${amount} to {recipient} authorized via PIC."
 
     def has_trusted_evidence(self, contract):
         # Logic to check if any provenance source is 'trusted'

--- a/sdk-python/evidence_checker.py
+++ b/sdk-python/evidence_checker.py
@@ -14,11 +14,11 @@ class PICEvidenceSystem:
         """
         Simulates verifying that a claim matches a trusted record.
         """
-        print(f"🔍 Checking evidence '{evidence_id}' for claim: {claim_text}")
+        print(f"Checking evidence '{evidence_id}' for claim: {claim_text}")
         return evidence_id in self.trusted_vault
 
 
 # Example Usage
 checker = PICEvidenceSystem()
 is_valid = checker.verify_financial_claim("Invoice matches CFO approval", "invoice_hash_001")
-print(f"Evidence Status: {'✅ TRUSTED' if is_valid else '❌ REJECTED'}")
+print(f"Evidence Status: {'TRUSTED' if is_valid else 'REJECTED'}")

--- a/sdk-python/pic_standard/cli.py
+++ b/sdk-python/pic_standard/cli.py
@@ -32,10 +32,10 @@ def cmd_schema(proposal_path: Path) -> int:
 
     try:
         js_validate(instance=proposal, schema=schema)
-        print("✅ Schema valid")
+        print("PASS: Schema valid")
         return 0
     except ValidationError as e:
-        print("❌ Schema invalid")
+        print("FAIL: Schema invalid")
         print(str(e))
         return 2
 
@@ -52,21 +52,21 @@ def cmd_evidence_verify(proposal_path: Path) -> int:
     report = es.verify_all(proposal, base_dir=proposal_path.parent)
 
     if not report.results:
-        print("❌ Evidence verification failed")
+        print("FAIL: Evidence verification failed")
         print("No evidence entries found in proposal (expected 'evidence': [...]).")
         return 4
 
     for r in report.results:
         if r.ok:
-            print(f"✅ Evidence {r.id}: {r.message}")
+            print(f"PASS: Evidence {r.id}: {r.message}")
         else:
-            print(f"❌ Evidence {r.id}: {r.message}")
+            print(f"FAIL: Evidence {r.id}: {r.message}")
 
     if report.ok:
-        print("✅ Evidence verification passed")
+        print("PASS: Evidence verification passed")
         return 0
 
-    print("❌ Evidence verification failed")
+    print("FAIL: Evidence verification failed")
     return 4
 
 
@@ -89,19 +89,19 @@ def cmd_verify(proposal_path: Path, *, verify_evidence: bool = False) -> int:
     )
 
     if result.ok:
-        print("✅ Verifier passed")
+        print("PASS: Verifier passed")
         return 0
 
     err = result.error
     if err and err.code == PICErrorCode.SCHEMA_INVALID:
-        print("❌ Schema invalid")
+        print("FAIL: Schema invalid")
         print(err.message)
         return 2
     if err and err.code in (PICErrorCode.EVIDENCE_REQUIRED, PICErrorCode.EVIDENCE_FAILED):
-        print("❌ Evidence verification failed")
+        print("FAIL: Evidence verification failed")
         print(err.message)
         return 4
-    print("❌ Verifier failed")
+    print("FAIL: Verifier failed")
     print(err.message if err else "Unknown error")
     return 3
 
@@ -141,15 +141,15 @@ def cmd_policy(*, repo_root: Path, write_example: bool = False) -> int:
             "require_pic_for_impacts": ["money", "privacy", "irreversible"],
             "require_evidence_for_impacts": ["money", "privacy", "irreversible"],
         }
-        print(json.dumps(example, indent=2, ensure_ascii=False))
+        print(json.dumps(example, indent=2, ensure_ascii=True))
         return 0
 
     policy = load_policy(repo_root=repo_root)
     source = _find_policy_source(repo_root)
 
-    print("✅ Policy loaded")
+    print("PASS: Policy loaded")
     print(f"Source: {source}")
-    print(json.dumps(dump_policy(policy), indent=2, ensure_ascii=False))
+    print(json.dumps(dump_policy(policy), indent=2, ensure_ascii=True))
     return 0
 
 
@@ -200,7 +200,7 @@ def cmd_keys(*, repo_root: Path, write_example: bool = False) -> int:
             },
             "revoked_keys": ["cfo_key_v1"],
         }
-        print(json.dumps(example, indent=2, ensure_ascii=False))
+        print(json.dumps(example, indent=2, ensure_ascii=True))
         return 0
 
     source = _find_keys_source(repo_root)
@@ -208,19 +208,19 @@ def cmd_keys(*, repo_root: Path, write_example: bool = False) -> int:
     try:
         ring = TrustedKeyRing.load_default()
     except KeyRingError as e:
-        print("❌ Keyring invalid")
+        print("FAIL: Keyring invalid")
         print(f"Source: {source}")
         print(str(e))
         return 6
     except Exception as e:
-        print("❌ Keyring failed to load")
+        print("FAIL: Keyring failed to load")
         print(f"Source: {source}")
         print(str(e))
         return 6
 
     key_ids = sorted(list(ring.keys.keys()))
 
-    print("✅ Keyring loaded")
+    print("PASS: Keyring loaded")
     print(f"Source: {source}")
 
     if not key_ids:

--- a/sdk-python/validate_proposal.py
+++ b/sdk-python/validate_proposal.py
@@ -13,9 +13,9 @@ def validate_pic_proposal(schema_path, proposal_path):
 
     try:
         validate(instance=proposal, schema=schema)
-        print("✅ PIC Contract is Schema-Valid.")
+        print("PASS: PIC Contract is Schema-Valid.")
     except ValidationError as e:
-        print(f"❌ Schema Violation: {e.message}")
+        print(f"FAIL: Schema Violation: {e.message}")
         sys.exit(1)
 
 

--- a/tests/test_cli_keys_command.py
+++ b/tests/test_cli_keys_command.py
@@ -34,7 +34,7 @@ def test_cli_keys_success_loads_from_pic_keys_path(monkeypatch, capsys, tmp_path
     assert rc == 0
 
     out = capsys.readouterr().out
-    assert "✅ Keyring loaded" in out
+    assert "PASS: Keyring loaded" in out
     assert "PIC_KEYS_PATH=" in out  # source hint should mention env
     assert "Trusted keys" in out
     assert "- demo_signer_v1" in out
@@ -60,7 +60,7 @@ def test_cli_keys_invalid_keyring_reports_error(monkeypatch, capsys, tmp_path: P
     assert rc != 0
 
     out = capsys.readouterr().out
-    assert "❌ Keyring" in out
+    assert "FAIL: Keyring" in out
     assert "Source:" in out
     # message should include why (not too brittle)
     assert "base64" in out.lower() or "invalid" in out.lower()

--- a/tests/test_cli_windows_encoding.py
+++ b/tests/test_cli_windows_encoding.py
@@ -1,0 +1,135 @@
+"""Regression test: CLI/demo runtime output must be ASCII-only.
+
+cp1252 (the default Windows console encoding) cannot encode common Unicode
+characters such as the check mark, cross mark, right arrow, em dash, en dash,
+curly quotes, or ellipsis. Until issue #120, the pic-cli emitted such
+characters and crashed on Windows consoles with UnicodeEncodeError.
+
+This test asserts that representative CLI subcommands produce ASCII-only
+stdout and stderr, with the expected exit code. encode("ascii") is
+intentionally stricter than encode("cp1252") because cp1252 happens to
+encode em dash, en dash, curly quotes, and ellipsis - so a cp1252-passing
+test would still let those slip through.
+
+Coverage: PASS path, FAIL path, and JSON-stdout path. Each asserts both
+ASCII safety AND the expected exit code so a malformed invocation cannot
+silently produce empty (and therefore trivially ASCII-safe) output.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pic_standard.cli import main as cli_main
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES = REPO_ROOT / "examples"
+
+
+def assert_ascii_safe(text: str, label: str) -> None:
+    """Assert that text encodes as ASCII (and therefore as cp1252 too)."""
+    try:
+        text.encode("ascii")
+    except UnicodeEncodeError as e:
+        pytest.fail(
+            f"{label} contains non-ASCII characters that would crash on "
+            f"cp1252 Windows consoles: {e}\n--- output ---\n{text}\n"
+            f"--- end ---"
+        )
+
+
+def run_cli_ascii_safe(monkeypatch, capsys, tmp_path, argv, expected_exit=0):
+    """Run a CLI invocation; assert ASCII safety on stdout+stderr AND exit code.
+
+    cli_main(...) returns an int directly under normal operation. argparse
+    may raise SystemExit for --help or bad flags; handle that defensively.
+    Non-int SystemExit codes are a contract violation and fail the test
+    rather than silently coerce, so a wrong invocation cannot pass merely
+    by producing empty output before failing.
+    """
+    monkeypatch.chdir(tmp_path)
+    try:
+        result = cli_main(argv)
+        if result is None:
+            exit_code = 0
+        elif isinstance(result, int):
+            exit_code = result
+        else:
+            pytest.fail(
+                f"argv={argv}: non-integer cli_main return: {result!r}"
+            )
+    except SystemExit as e:
+        if e.code is None:
+            exit_code = 0
+        elif isinstance(e.code, int):
+            exit_code = e.code
+        else:
+            pytest.fail(
+                f"argv={argv}: non-integer SystemExit code: {e.code!r}"
+            )
+
+    captured = capsys.readouterr()
+    assert_ascii_safe(captured.out, f"stdout for argv={argv}")
+    assert_ascii_safe(captured.err, f"stderr for argv={argv}")
+    assert exit_code == expected_exit, (
+        f"argv={argv}: expected exit {expected_exit}, got {exit_code}"
+    )
+
+
+# PASS-path invocations + JSON-stdout invocations
+PASS_INVOCATIONS = [
+    pytest.param(
+        ["schema", str(EXAMPLES / "read_only_query.json")], 0,
+        id="schema-valid",
+    ),
+    pytest.param(
+        ["verify", str(EXAMPLES / "read_only_query.json")], 0,
+        id="verify-low-impact-allow",
+    ),
+    # JSON-stdout paths (cli.py L144 / L152 / L203 use ensure_ascii=True
+    # after the issue #120 fix; these invocations exercise that path).
+    pytest.param(
+        ["policy", "--write-example"], 0,
+        id="policy-write-example-json-stdout",
+    ),
+    pytest.param(
+        ["keys", "--write-example"], 0,
+        id="keys-write-example-json-stdout",
+    ),
+]
+
+
+@pytest.mark.parametrize("argv,expected_exit", PASS_INVOCATIONS)
+def test_cli_pass_and_json_paths_ascii_safe(
+    monkeypatch, capsys, tmp_path, argv, expected_exit,
+):
+    """PASS-path and JSON-stdout CLI output must be ASCII-only with correct exit."""
+    run_cli_ascii_safe(monkeypatch, capsys, tmp_path, argv, expected_exit)
+
+
+def test_cli_schema_fail_path_ascii_safe(monkeypatch, capsys, tmp_path):
+    """FAIL-path CLI output must also be ASCII-only with non-zero exit.
+
+    Uses a runtime-generated invalid proposal (not a committed fixture);
+    same isolation pattern as tests/test_cli_keys_command.py uses for
+    keyring fixtures.
+
+    Exit code 2 is the verified contract: cmd_schema returns 2 on
+    jsonschema.ValidationError (sdk-python/pic_standard/cli.py
+    cmd_schema, "return 2" on the ValidationError branch).
+    """
+    invalid = tmp_path / "invalid_proposal.json"
+    # Structurally invalid: missing required fields ("impact", "provenance",
+    # "claims", "action") per the PIC/1.0 JSON Schema. jsonschema raises
+    # ValidationError; cmd_schema returns 2.
+    invalid.write_text(
+        '{"protocol": "PIC/1.0", "intent": "incomplete proposal"}',
+        encoding="utf-8",
+    )
+    run_cli_ascii_safe(
+        monkeypatch, capsys, tmp_path,
+        ["schema", str(invalid)],
+        expected_exit=2,
+    )

--- a/tests/test_cli_windows_encoding.py
+++ b/tests/test_cli_windows_encoding.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-
 from pic_standard.cli import main as cli_main
 
 REPO_ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_cli_windows_encoding.py
+++ b/tests/test_cli_windows_encoding.py
@@ -56,18 +56,14 @@ def run_cli_ascii_safe(monkeypatch, capsys, tmp_path, argv, expected_exit=0):
         elif isinstance(result, int):
             exit_code = result
         else:
-            pytest.fail(
-                f"argv={argv}: non-integer cli_main return: {result!r}"
-            )
+            pytest.fail(f"argv={argv}: non-integer cli_main return: {result!r}")
     except SystemExit as e:
         if e.code is None:
             exit_code = 0
         elif isinstance(e.code, int):
             exit_code = e.code
         else:
-            pytest.fail(
-                f"argv={argv}: non-integer SystemExit code: {e.code!r}"
-            )
+            pytest.fail(f"argv={argv}: non-integer SystemExit code: {e.code!r}")
 
     captured = capsys.readouterr()
     assert_ascii_safe(captured.out, f"stdout for argv={argv}")
@@ -80,21 +76,25 @@ def run_cli_ascii_safe(monkeypatch, capsys, tmp_path, argv, expected_exit=0):
 # PASS-path invocations + JSON-stdout invocations
 PASS_INVOCATIONS = [
     pytest.param(
-        ["schema", str(EXAMPLES / "read_only_query.json")], 0,
+        ["schema", str(EXAMPLES / "read_only_query.json")],
+        0,
         id="schema-valid",
     ),
     pytest.param(
-        ["verify", str(EXAMPLES / "read_only_query.json")], 0,
+        ["verify", str(EXAMPLES / "read_only_query.json")],
+        0,
         id="verify-low-impact-allow",
     ),
     # JSON-stdout paths (cli.py L144 / L152 / L203 use ensure_ascii=True
     # after the issue #120 fix; these invocations exercise that path).
     pytest.param(
-        ["policy", "--write-example"], 0,
+        ["policy", "--write-example"],
+        0,
         id="policy-write-example-json-stdout",
     ),
     pytest.param(
-        ["keys", "--write-example"], 0,
+        ["keys", "--write-example"],
+        0,
         id="keys-write-example-json-stdout",
     ),
 ]
@@ -102,7 +102,11 @@ PASS_INVOCATIONS = [
 
 @pytest.mark.parametrize("argv,expected_exit", PASS_INVOCATIONS)
 def test_cli_pass_and_json_paths_ascii_safe(
-    monkeypatch, capsys, tmp_path, argv, expected_exit,
+    monkeypatch,
+    capsys,
+    tmp_path,
+    argv,
+    expected_exit,
 ):
     """PASS-path and JSON-stdout CLI output must be ASCII-only with correct exit."""
     run_cli_ascii_safe(monkeypatch, capsys, tmp_path, argv, expected_exit)
@@ -128,7 +132,9 @@ def test_cli_schema_fail_path_ascii_safe(monkeypatch, capsys, tmp_path):
         encoding="utf-8",
     )
     run_cli_ascii_safe(
-        monkeypatch, capsys, tmp_path,
+        monkeypatch,
+        capsys,
+        tmp_path,
         ["schema", str(invalid)],
         expected_exit=2,
     )


### PR DESCRIPTION
Fixes the `UnicodeEncodeError` crash on Windows cp1252 consoles by replacing emoji and Unicode arrows in CLI / demo runtime emission with ASCII labels (`PASS:`, `FAIL:`, `->`). Also tightens `cli.py`'s JSON stdout to `ensure_ascii=True` so the `policy` and `keys` subcommands stay ASCII-safe regardless of input data.

## What changed

### Runtime emission paths (ASCII fix)
- `sdk-python/pic_standard/cli.py` - 15 emoji prints + 3 `ensure_ascii=False` -> `True`
- `examples/mcp_pic_client_demo.py` - 5 prints
- `examples/langgraph_pic_toolnode_demo.py` - 4 prints
- `sdk-python/crewai_pic_tool.py` - 2 returned strings; emoji dropped, prose kept (these go to a CrewAI agent, not a CLI terminal)
- `sdk-python/evidence_checker.py` - 2 prints
- `sdk-python/validate_proposal.py` - 2 prints
- `examples/_gen_sig_example.py` - 1 print
- `examples/openclaw_pic_bridge_demo.py` - 1 `log.info` arrow

### Tests
- `tests/test_cli_keys_command.py` - 2 assertion updates to match the new ASCII output.
- `tests/test_cli_windows_encoding.py` - **new** parametrized regression test:
  - **PASS path** (schema-valid, verify low-impact)
  - **JSON-stdout path** (`policy --write-example`, `keys --write-example`)
  - **FAIL path** (schema-invalid, `expected_exit=2` per the verified `cmd_schema` contract)
  - Asserts both stdout AND stderr each `.encode("ascii")` (stricter than `cp1252` - catches em dash, en dash, curly quotes, ellipsis too).
  - Uses an `expected_exit` helper so a wrong invocation cannot pass by producing empty output before crashing. Non-integer `SystemExit` codes fail rather than silently coerce.

## Verification (local)
- 8/8 tests pass in `tests/test_cli_windows_encoding.py` + `tests/test_cli_keys_command.py`.
- Post-edit audit: 0 non-ASCII characters in any runtime-emission site across the 8 fixed files. Docstring/comment Unicode preserved per policy.

## Out of scope (separate concerns)
- Docstring / comment / changelog / docs / notebook Unicode (intentional).
- `ensure_ascii=False` in `http_bridge.py:215` (UTF-8 file handler, not terminal) and `mcp_pic_guard.py:82` (logger destination is deployment-dependent). Same risk class, separate trigger.
- Adding `windows-latest` to the CI matrix - structural cause; will open a separate follow-up issue after this PR opens so #120 stays focused.

Closes #120
